### PR TITLE
feat(feeds): add AgentBets prediction market feed

### DIFF
--- a/src/feeds/agentbets/index.ts
+++ b/src/feeds/agentbets/index.ts
@@ -1,0 +1,184 @@
+/**
+ * AgentBets Feed
+ * Prediction markets for AI agents on Solana devnet
+ * 
+ * Built for the Colosseum Agent Hackathon
+ * https://github.com/nox-oss/agentbets
+ */
+
+import { EventEmitter } from 'events';
+import { Market, Outcome, Platform } from '../../types';
+import { logger } from '../../utils/logger';
+
+const API_URL = 'https://agentbets-api-production.up.railway.app';
+
+interface AgentBetsMarket {
+  id: string;
+  question: string;
+  description?: string;
+  outcomes: Array<{
+    name: string;
+    shares: number;
+  }>;
+  totalPool: number;
+  status: 'open' | 'resolved' | 'disputed';
+  resolutionTime: string;
+  winningOutcome?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface AgentBetsResponse {
+  markets: AgentBetsMarket[];
+  count: number;
+}
+
+export interface AgentBetsFeed extends EventEmitter {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  searchMarkets: (query?: string) => Promise<Market[]>;
+  getMarket: (id: string) => Promise<Market | null>;
+  getOpportunities: () => Promise<any[]>;
+}
+
+export async function createAgentBetsFeed(): Promise<AgentBetsFeed> {
+  const emitter = new EventEmitter();
+  let pollInterval: NodeJS.Timer | null = null;
+  const POLL_INTERVAL_MS = 30000; // 30 seconds
+
+  function convertToMarket(m: AgentBetsMarket): Market {
+    const totalShares = m.outcomes.reduce((sum, o) => sum + o.shares, 0) || 1;
+    
+    const outcomes: Outcome[] = m.outcomes.map((o, idx) => ({
+      id: `${m.id}-${idx}`,
+      name: o.name,
+      price: totalShares > 0 ? o.shares / totalShares : 0.5,
+      volume24h: 0, // Not tracked yet
+    }));
+
+    return {
+      id: m.id,
+      platform: 'agentbets' as Platform,
+      slug: m.id,
+      question: m.question,
+      description: m.description,
+      outcomes,
+      volume24h: m.totalPool,
+      liquidity: m.totalPool,
+      endDate: new Date(m.resolutionTime),
+      resolved: m.status === 'resolved',
+      resolutionValue: m.winningOutcome ? 
+        (m.outcomes.findIndex(o => o.name === m.winningOutcome) === 0 ? 1 : 0) : 
+        undefined,
+      tags: ['agent-hackathon', 'solana'],
+      url: `https://github.com/nox-oss/agentbets#${m.id}`,
+      createdAt: new Date(m.createdAt),
+      updatedAt: new Date(m.updatedAt),
+    };
+  }
+
+  async function fetchMarkets(): Promise<Market[]> {
+    try {
+      const response = await fetch(`${API_URL}/markets`);
+      
+      if (!response.ok) {
+        throw new Error(`AgentBets API error: ${response.status}`);
+      }
+
+      const data = await response.json() as AgentBetsResponse;
+      return data.markets.map(convertToMarket);
+    } catch (error) {
+      logger.error('AgentBets: Fetch error', error);
+      return [];
+    }
+  }
+
+  async function searchMarkets(query?: string): Promise<Market[]> {
+    const markets = await fetchMarkets();
+    
+    if (!query) return markets;
+    
+    const lowerQuery = query.toLowerCase();
+    return markets.filter(m => 
+      m.question.toLowerCase().includes(lowerQuery) ||
+      m.description?.toLowerCase().includes(lowerQuery)
+    );
+  }
+
+  async function getMarket(id: string): Promise<Market | null> {
+    try {
+      const response = await fetch(`${API_URL}/markets/${id}`);
+      
+      if (!response.ok) {
+        if (response.status === 404) return null;
+        throw new Error(`AgentBets API error: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return convertToMarket(data.market);
+    } catch (error) {
+      logger.error(`AgentBets: Error fetching market ${id}`, error);
+      return null;
+    }
+  }
+
+  async function getOpportunities(): Promise<any[]> {
+    try {
+      const response = await fetch(`${API_URL}/opportunities`);
+      
+      if (!response.ok) {
+        throw new Error(`AgentBets API error: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.opportunities || [];
+    } catch (error) {
+      logger.error('AgentBets: Opportunities fetch error', error);
+      return [];
+    }
+  }
+
+  function startPolling(): void {
+    if (pollInterval) return;
+    
+    pollInterval = setInterval(async () => {
+      try {
+        const markets = await fetchMarkets();
+        emitter.emit('markets', markets);
+      } catch (error) {
+        logger.error('AgentBets: Polling error', error);
+      }
+    }, POLL_INTERVAL_MS);
+  }
+
+  function stopPolling(): void {
+    if (pollInterval) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+  }
+
+  return Object.assign(emitter, {
+    async connect(): Promise<void> {
+      logger.info('AgentBets: Connecting...');
+      
+      // Fetch initial markets
+      const markets = await fetchMarkets();
+      logger.info(`AgentBets: Loaded ${markets.length} markets`);
+      emitter.emit('connected');
+      emitter.emit('markets', markets);
+      
+      // Start polling
+      startPolling();
+    },
+
+    disconnect(): void {
+      stopPolling();
+      emitter.emit('disconnected');
+    },
+
+    searchMarkets,
+    getMarket,
+    getOpportunities,
+  }) as AgentBetsFeed;
+}

--- a/src/feeds/descriptors.ts
+++ b/src/feeds/descriptors.ts
@@ -155,6 +155,29 @@ const drift: FeedDescriptor = {
   },
 };
 
+const agentbets: FeedDescriptor = {
+  id: 'agentbets',
+  name: 'AgentBets',
+  description: 'Prediction markets for AI agents on Solana devnet — built for the Colosseum hackathon',
+  status: 'available',
+  skillCommand: '/agentbets',
+  category: 'prediction_market',
+  capabilities: [
+    FeedCapability.MARKET_DATA,
+    FeedCapability.EDGE_DETECTION,
+  ],
+  dataTypes: ['markets', 'prices', 'opportunities'],
+  connectionType: 'polling',
+  requiredEnv: [],
+  optionalEnv: [],
+  configKey: undefined,
+  docsUrl: 'https://github.com/nox-oss/agentbets',
+  create: async () => {
+    const { createAgentBetsFeed } = await import('./agentbets/index');
+    return createAgentBetsFeed() as any;
+  },
+};
+
 const betfair: FeedDescriptor = {
   id: 'betfair',
   name: 'Betfair',
@@ -497,6 +520,7 @@ export function registerAllFeeds(): void {
   registry.register(metaculus);
   registry.register(predictit);
   registry.register(drift);
+  registry.register(agentbets);
   registry.register(betfair);
   registry.register(smarkets);
   registry.register(opinion);
@@ -519,7 +543,7 @@ export function registerAllFeeds(): void {
 
 /** Get all descriptor objects for programmatic access. */
 export const allDescriptors: FeedDescriptor[] = [
-  polymarket, kalshi, manifold, metaculus, predictit, drift,
+  polymarket, kalshi, manifold, metaculus, predictit, drift, agentbets,
   betfair, smarkets, opinion, predictfunDesc, hedgehog, virtuals,
   polymarketRtds, crypto, news, externalData,
   weatherOpenMeteo, weatherNWS, acledConflict, fredEconomics,


### PR DESCRIPTION
## Summary

Adds AgentBets as a new prediction market data source — the 10th prediction market in Clodds!

## What's included

### New feed: `src/feeds/agentbets/index.ts`
- Polling-based feed for Solana devnet markets
- `searchMarkets(query)` — find markets by keyword
- `getMarket(id)` — fetch single market details
- `getOpportunities()` — get +EV betting opportunities

### Descriptor registration
- Added to `src/feeds/descriptors.ts`
- Skill command: `/agentbets`
- Capabilities: `MARKET_DATA`, `EDGE_DETECTION`

## Why AgentBets?

AgentBets is a prediction market built specifically for AI agents during the Colosseum hackathon. It features:

- **Parimutuel betting** — simple pool-based markets
- **Edge detection** — `/opportunities` endpoint finds mispriced markets
- **Agent-native API** — designed for programmatic access
- **Solana devnet** — low-cost testing and iteration

## Links

- **API**: https://agentbets-api-production.up.railway.app
- **Repo**: https://github.com/nox-oss/agentbets
- **Hackathon**: https://colosseum.com/agent-hackathon/projects/agentbets

## Testing

```bash
# List markets
curl https://agentbets-api-production.up.railway.app/markets

# Get opportunities
curl https://agentbets-api-production.up.railway.app/opportunities
```

---

*Built by [nox](https://colosseum.com/agent-hackathon/agents/691) for the Colosseum Agent Hackathon* 🤝