### PR TITLE
fix(gateway): wire alert service with stub price provider

### DIFF
--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -592,6 +592,15 @@ export async function createGateway(config: Config): Promise<AppGateway> {
 
   // DCA router is wired later (after executionService is created) so it can start the engine
 
+  // Create alert service with stub price provider (no alerts configured yet;
+  // real price feed wired when alert monitoring is needed)
+  const alertsMod = await import('../alerts/index.js');
+  const stubPriceProvider: import('../alerts/index.js').PriceProvider = {
+    async getPrice() { return null; },
+    async getVolume24h() { return null; },
+  };
+  let alertService: import('../alerts/index.js').AlertService | null = alertsMod.createAlertService(stubPriceProvider, null);
+
   // Create alt-data sentiment pipeline if enabled
   let altDataService: AltDataService | null = null;
 
@@ -858,7 +867,7 @@ export async function createGateway(config: Config): Promise<AppGateway> {
   // Wire Alerts API (lazy — alertService may not be instantiated)
   {
     const { createAlertsRouter } = await import('./alerts-routes.js');
-    httpGateway.setAlertsRouter(createAlertsRouter({ getService: () => null }));
+    httpGateway.setAlertsRouter(createAlertsRouter({ getService: () => alertService }));
     logger.info('Alerts API wired (service injected when available)');
   }
 


### PR DESCRIPTION
## Summary

`/api/alerts` returns `500 Internal Error` on every request because the alerts router is wired with `getService: () => null`. The `createAlertService()` factory in `src/alerts/index.ts` is never called during gateway init, so no service ever exists for the router to dispatch to.

This patch instantiates `alertService` at gateway creation with a stub `PriceProvider` (returns `null` for price/volume — safe because no alerts are actually configured yet) and injects the closure into `createAlertsRouter`.

When alert monitoring is later wired up to a real price feed, the only change needed is to construct the real `PriceProvider` in place of the stub.

## Changes

`src/gateway/index.ts` — 10 insertions, 1 deletion:

1. Line ~595: import the alerts module, construct a stub `PriceProvider`, and call `createAlertService()`.
2. Line ~870: change `getService: () => null` → `getService: () => alertService`.

## Verification

After build + restart on a fork running this patch:

\`\`\`bash
$ curl -H "Authorization: Bearer \$CLODDS_TOKEN" http://localhost:18789/api/alerts
{"ok":true,"data":{"alerts":[],"count":0}}
\`\`\`

(Was returning 500 before.)

## Discovery

This bug was discovered by an autonomous CEO agent running on a CloddsBot fork. During a routine heartbeat health check, the agent called `/api/alerts`, got a 500, traced the failure to \`src/gateway/index.ts\` line ~861, wrote this exact patch, ran `npm run build` successfully, and then correctly refused to restart the gateway without human approval (per its operating rules). The PR is the human follow-up to ship the agent's fix upstream.

## Test plan

- [x] `npm run build` clean
- [x] `/api/alerts` returns `{ok:true,data:{alerts:[],count:0}}` instead of 500
- [x] No regressions in other gateway routes (\`/api/portfolio\`, \`/api/positions\`, \`/_control/status\`, \`/api/monitoring/health\` all still 200)
- [ ] CI green (please run)

## Notes

The stub `PriceProvider` is intentionally minimal — it's a no-op that lets the alert service exist without crashing on uninitialized state. If the project would prefer a more explicit "alerts disabled" flag rather than a stub, happy to refactor.