### PR TITLE
feat(alt-data): add optional Adanos sentiment feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,12 @@ BITTENSOR_NETWORK=mainnet
 # Earnings poll interval in ms (optional - defaults to 300000 / 5 min)
 # BITTENSOR_EARNINGS_POLL_INTERVAL_MS=300000
 
+# Optional Adanos crypto sentiment feed (https://adanos.org/register)
+ALT_DATA_ADANOS_ENABLED=false
+ADANOS_API_KEY=
+# Three hours stays within the Free plan's 250 monthly requests.
+# ALT_DATA_ADANOS_INTERVAL_MS=10800000
+
 # ============================================================================
 # API / Compute Marketplace (Revenue Collection)
 # ============================================================================

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -619,6 +619,7 @@ export const DEFAULT_CONFIG: CloddsConfig = {
     fearGreedEnabled: true,
     fundingRatesEnabled: true,
     redditEnabled: false,
+    adanosEnabled: false,
   },
   signalRouter: {
     enabled: false,
@@ -1086,6 +1087,20 @@ const ENV_MAPPINGS: Record<string, (cfg: CloddsConfig) => void> = {
     if (!cfg.altData) cfg.altData = {};
     const raw = process.env.ALT_DATA_REDDIT_SUBREDDITS;
     if (raw) cfg.altData.redditSubreddits = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  },
+  ADANOS_API_KEY: (cfg) => {
+    if (!cfg.altData) cfg.altData = {};
+    cfg.altData.adanosApiKey = process.env.ADANOS_API_KEY;
+  },
+  ALT_DATA_ADANOS_ENABLED: (cfg) => {
+    if (!cfg.altData) cfg.altData = {};
+    const raw = process.env.ALT_DATA_ADANOS_ENABLED;
+    if (raw) cfg.altData.adanosEnabled = raw === '1' || raw.toLowerCase() === 'true';
+  },
+  ALT_DATA_ADANOS_INTERVAL_MS: (cfg) => {
+    if (!cfg.altData) cfg.altData = {};
+    const raw = process.env.ALT_DATA_ADANOS_INTERVAL_MS;
+    if (raw) cfg.altData.adanosIntervalMs = safeParseInt(raw) ?? cfg.altData.adanosIntervalMs;
   },
   SIGNAL_ROUTER_ENABLED: (cfg) => {
     if (!cfg.signalRouter) cfg.signalRouter = {};

--- a/src/services/alt-data/feeds/adanos.ts
+++ b/src/services/alt-data/feeds/adanos.ts
@@ -1,0 +1,144 @@
+/** Optional Adanos crypto sentiment feed. */
+
+import type { AltDataEvent } from '../types.js';
+import { logger } from '../../../utils/logger.js';
+
+const ENDPOINT = 'https://api.adanos.org/reddit/crypto/v1/trending';
+const DEFAULT_INTERVAL_MS = 10_800_000; // 3 hours: 240 requests per 30-day month
+const DEFAULT_LIMIT = 20;
+const MIN_INTERVAL_MS = 60_000;
+const MAX_INTERVAL_MS = 2_147_483_647;
+
+interface AdanosToken {
+  symbol?: unknown;
+  name?: unknown;
+  sentiment_score?: unknown;
+  buzz_score?: unknown;
+  mentions?: unknown;
+  trend?: unknown;
+  bullish_pct?: unknown;
+  bearish_pct?: unknown;
+}
+
+export interface AdanosFeed {
+  start(): void;
+  stop(): void;
+  poll(): Promise<AltDataEvent[]>;
+}
+
+export function createAdanosFeed(
+  onEvent: (event: AltDataEvent) => void,
+  apiKey: string,
+  intervalMs: number = DEFAULT_INTERVAL_MS,
+  limit: number = DEFAULT_LIMIT,
+): AdanosFeed {
+  if (!apiKey.trim()) throw new Error('Adanos API key is required');
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) throw new Error('Adanos limit must be an integer from 1 to 100');
+  if (!Number.isInteger(intervalMs) || intervalMs < MIN_INTERVAL_MS || intervalMs > MAX_INTERVAL_MS) {
+    throw new Error(`Adanos interval must be an integer from ${MIN_INTERVAL_MS} to ${MAX_INTERVAL_MS} ms`);
+  }
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let generation = 0;
+  const snapshots = new Map<string, string>();
+  const activeControllers = new Set<AbortController>();
+
+  async function fetchEvents(expectedGeneration?: number): Promise<AltDataEvent[]> {
+    const controller = new AbortController();
+    activeControllers.add(controller);
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    try {
+      const url = new URL(ENDPOINT);
+      url.searchParams.set('limit', String(limit));
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: { 'X-API-Key': apiKey },
+      });
+      if (!response.ok) {
+        logger.debug({ status: response.status }, '[adanos] Sentiment fetch failed');
+        return [];
+      }
+
+      const payload = await response.json() as unknown;
+      if (!Array.isArray(payload)) {
+        logger.debug('[adanos] Invalid sentiment response');
+        return [];
+      }
+      if (expectedGeneration !== undefined && expectedGeneration !== generation) return [];
+
+      const events: AltDataEvent[] = [];
+      for (const item of payload as AdanosToken[]) {
+        const symbol = typeof item.symbol === 'string' ? item.symbol.trim().toUpperCase() : '';
+        const sentiment = typeof item.sentiment_score === 'number' && Number.isFinite(item.sentiment_score)
+          ? Math.max(-1, Math.min(1, item.sentiment_score))
+          : null;
+        if (!/^[A-Z0-9]{1,20}$/.test(symbol) || sentiment === null) continue;
+
+        const mentions = typeof item.mentions === 'number' && Number.isFinite(item.mentions) ? Math.max(0, item.mentions) : 0;
+        const buzzScore = typeof item.buzz_score === 'number' && Number.isFinite(item.buzz_score) ? item.buzz_score : null;
+        const signature = JSON.stringify([
+          sentiment,
+          mentions,
+          buzzScore,
+          item.trend,
+          item.bullish_pct,
+          item.bearish_pct,
+        ]);
+        if (snapshots.get(symbol) === signature) continue;
+        snapshots.set(symbol, signature);
+
+        const name = typeof item.name === 'string' && item.name.trim() ? item.name.trim() : symbol;
+        const event: AltDataEvent = {
+          id: `adanos-${symbol}-${Date.now()}`,
+          source: 'adanos_sentiment',
+          timestamp: Date.now(),
+          text: `${name} (${symbol}) crypto market sentiment`,
+          numericValue: sentiment,
+          categories: ['crypto', symbol.toLowerCase(), 'adanos'],
+          meta: {
+            symbol,
+            mentions,
+            buzzScore,
+            trend: item.trend,
+            bullishPct: item.bullish_pct,
+            bearishPct: item.bearish_pct,
+          },
+        };
+        if (expectedGeneration !== undefined && expectedGeneration !== generation) return [];
+        events.push(event);
+        onEvent(event);
+      }
+      return events;
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') logger.debug({ error }, '[adanos] Sentiment poll failed');
+      return [];
+    } finally {
+      clearTimeout(timeout);
+      activeControllers.delete(controller);
+    }
+  }
+
+  function poll(): Promise<AltDataEvent[]> {
+    return fetchEvents(generation);
+  }
+
+  function start(): void {
+    if (timer) return;
+    const runGeneration = ++generation;
+    fetchEvents(runGeneration).catch((error) => logger.error({ error }, '[adanos] Feed poll failed'));
+    timer = setInterval(() => {
+      fetchEvents(runGeneration).catch((error) => logger.error({ error }, '[adanos] Feed poll failed'));
+    }, intervalMs);
+    logger.info({ intervalMs, limit }, '[adanos] Feed started');
+  }
+
+  function stop(): void {
+    generation++;
+    if (timer) clearInterval(timer);
+    timer = null;
+    for (const controller of activeControllers) controller.abort();
+    activeControllers.clear();
+  }
+
+  return { start, stop, poll };
+}

--- a/src/services/alt-data/index.ts
+++ b/src/services/alt-data/index.ts
@@ -13,6 +13,7 @@ import { createMarketMatcher } from './market-matcher.js';
 import { createFearGreedFeed, type FearGreedFeed } from './feeds/fear-greed.js';
 import { createFundingRatesFeed, type FundingRatesFeed } from './feeds/funding-rates.js';
 import { createRedditFeed, type RedditFeed } from './feeds/reddit.js';
+import { createAdanosFeed, type AdanosFeed } from './feeds/adanos.js';
 import { logger } from '../../utils/logger.js';
 
 // ── Config defaults ────────────────────────────────────────────────────────
@@ -30,6 +31,10 @@ const DEFAULTS: Required<AltDataConfig> = {
   redditEnabled: false,
   redditIntervalMs: 300_000,
   redditSubreddits: ['polymarket', 'cryptocurrency', 'wallstreetbets'],
+  adanosEnabled: false,
+  adanosApiKey: '',
+  adanosIntervalMs: 10_800_000,
+  adanosLimit: 20,
 };
 
 // ── Dependencies (loose coupling) ──────────────────────────────────────────
@@ -87,6 +92,7 @@ export function createAltDataService(opts: AltDataServiceOptions): AltDataServic
   let fearGreedFeed: FearGreedFeed | null = null;
   let fundingRatesFeed: FundingRatesFeed | null = null;
   let redditFeed: RedditFeed | null = null;
+  let adanosFeed: AdanosFeed | null = null;
 
   // News bridge listener (stored for cleanup on stop)
   let newsListener: ((...args: unknown[]) => void) | null = null;
@@ -247,6 +253,15 @@ export function createAltDataService(opts: AltDataServiceOptions): AltDataServic
       redditFeed.start();
     }
 
+    if (cfg.adanosEnabled) {
+      if (cfg.adanosApiKey) {
+        adanosFeed = createAdanosFeed(onFeedEvent, cfg.adanosApiKey, cfg.adanosIntervalMs, cfg.adanosLimit);
+        adanosFeed.start();
+      } else {
+        logger.warn('[alt-data] Adanos feed enabled without ADANOS_API_KEY; feed disabled');
+      }
+    }
+
     // Bridge existing news events if FeedManager is available
     if (opts.feeds?.on) {
       newsListener = (item: unknown) => {
@@ -284,9 +299,11 @@ export function createAltDataService(opts: AltDataServiceOptions): AltDataServic
     fearGreedFeed?.stop();
     fundingRatesFeed?.stop();
     redditFeed?.stop();
+    adanosFeed?.stop();
     fearGreedFeed = null;
     fundingRatesFeed = null;
     redditFeed = null;
+    adanosFeed = null;
     // Clear pending queue
     eventQueue.length = 0;
     logger.info({ eventsProcessed, signalsEmitted }, '[alt-data] Service stopped');
@@ -297,6 +314,7 @@ export function createAltDataService(opts: AltDataServiceOptions): AltDataServic
     if (fearGreedFeed) active.push('fear_greed');
     if (fundingRatesFeed) active.push('funding_rates');
     if (redditFeed) active.push('reddit');
+    if (adanosFeed) active.push('adanos');
     if (opts.feeds?.on) active.push('news_bridge');
     return active;
   }

--- a/src/services/alt-data/sentiment.ts
+++ b/src/services/alt-data/sentiment.ts
@@ -239,6 +239,18 @@ function scoreFundingRate(value: number): SentimentResult {
   };
 }
 
+function scoreAdanosSentiment(value: number, mentions: number): SentimentResult {
+  const score = Math.max(-1, Math.min(1, value));
+  const confidence = Math.min(1, Math.max(0.3, Math.log10(Math.max(0, mentions) + 1) / 3));
+  return {
+    score,
+    confidence,
+    label: scoreToLabel(score),
+    matchedKeywords: ['adanos_sentiment'],
+    category: 'crypto',
+  };
+}
+
 // ── Factory ────────────────────────────────────────────────────────────────
 
 export function createSentimentAnalyzer(): SentimentAnalyzer {
@@ -252,6 +264,10 @@ export function createSentimentAnalyzer(): SentimentAnalyzer {
     }
     if (event.source === 'funding_rate' && event.numericValue !== undefined) {
       return scoreFundingRate(event.numericValue);
+    }
+    if (event.source === 'adanos_sentiment' && event.numericValue !== undefined) {
+      const mentions = typeof event.meta?.mentions === 'number' ? event.meta.mentions : 0;
+      return scoreAdanosSentiment(event.numericValue, mentions);
     }
 
     // Text-based scoring (truncate to cap processing time)

--- a/src/services/alt-data/types.ts
+++ b/src/services/alt-data/types.ts
@@ -13,7 +13,8 @@ export type AltDataSourceType =
   | 'news_headline'
   | 'reddit_post'
   | 'fear_greed'
-  | 'funding_rate';
+  | 'funding_rate'
+  | 'adanos_sentiment';
 
 // ── Core events ────────────────────────────────────────────────────────────
 
@@ -93,6 +94,12 @@ export interface AltDataConfig {
   redditEnabled?: boolean;
   redditIntervalMs?: number;
   redditSubreddits?: string[];
+
+  // Adanos crypto sentiment
+  adanosEnabled?: boolean;
+  adanosApiKey?: string;
+  adanosIntervalMs?: number;
+  adanosLimit?: number;
 }
 
 // ── Service interface ──────────────────────────────────────────────────────

--- a/tests/unit/alt-data.test.ts
+++ b/tests/unit/alt-data.test.ts
@@ -112,6 +112,21 @@ describe('sentiment analyzer', () => {
     assert.ok(negative_funding.score > 0, `Expected positive score for negative funding, got ${negative_funding.score}`);
   });
 
+  it('uses Adanos numeric sentiment without keyword rescoring', () => {
+    const result = analyzer.analyze({
+      id: 'adanos-1',
+      source: 'adanos_sentiment',
+      timestamp: Date.now(),
+      text: 'Bitcoin market sentiment',
+      numericValue: -0.42,
+      categories: ['crypto'],
+      meta: { mentions: 100 },
+    });
+    assert.equal(result.score, -0.42);
+    assert.equal(result.label, 'bearish');
+    assert.ok(result.confidence > 0.6);
+  });
+
   it('returns neutral for empty/irrelevant text', () => {
     const result = analyzer.analyze({
       id: 'test-4',
@@ -362,5 +377,62 @@ describe('reddit feed', () => {
     assert.equal(typeof feed.start, 'function');
     assert.equal(typeof feed.stop, 'function');
     assert.equal(typeof feed.poll, 'function');
+  });
+});
+
+describe('Adanos feed', () => {
+  it('rejects unsafe polling intervals', async () => {
+    const mod = await import('../../src/services/alt-data/feeds/adanos.js');
+    assert.throws(() => mod.createAdanosFeed(() => {}, process.env.PATH ?? '', 0), /Adanos interval/);
+    assert.throws(() => mod.createAdanosFeed(() => {}, process.env.PATH ?? '', 2_147_483_648), /Adanos interval/);
+  });
+
+  it('emits validated changed sentiment snapshots', async () => {
+    const originalFetch = globalThis.fetch;
+    let bullishPct = 60;
+    globalThis.fetch = (async (_url: URL, init?: RequestInit) => {
+      assert.equal((init?.headers as Record<string, string>)['X-API-Key'], process.env.PATH);
+      return new Response(JSON.stringify([
+        { symbol: 'btc', name: 'Bitcoin', sentiment_score: 0.35, buzz_score: 72, mentions: 150, trend: 'rising', bullish_pct: bullishPct },
+        { symbol: '../bad', sentiment_score: 0.5 },
+      ]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as typeof fetch;
+    try {
+      const mod = await import('../../src/services/alt-data/feeds/adanos.js');
+      const emitted: any[] = [];
+      const feed = mod.createAdanosFeed((event) => emitted.push(event), process.env.PATH ?? '', 60_000, 10);
+      const first = await feed.poll();
+      const second = await feed.poll();
+      bullishPct = 61;
+      const changed = await feed.poll();
+      assert.equal(first.length, 1);
+      assert.equal(second.length, 0);
+      assert.equal(changed.length, 1);
+      assert.equal(emitted[0].source, 'adanos_sentiment');
+      assert.equal(emitted[0].numericValue, 0.35);
+      assert.equal(emitted[0].meta.symbol, 'BTC');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not emit an in-flight manual poll after stop', async () => {
+    const originalFetch = globalThis.fetch;
+    let resolveFetch!: (response: Response) => void;
+    globalThis.fetch = (() => new Promise<Response>((resolve) => { resolveFetch = resolve; })) as typeof fetch;
+    try {
+      const mod = await import('../../src/services/alt-data/feeds/adanos.js');
+      const emitted: any[] = [];
+      const feed = mod.createAdanosFeed((event) => emitted.push(event), process.env.PATH ?? '', 60_000, 10);
+      const pending = feed.poll();
+      feed.stop();
+      resolveFetch(new Response(JSON.stringify([
+        { symbol: 'BTC', sentiment_score: 0.5, mentions: 100 },
+      ]), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      await pending;
+      assert.equal(emitted.length, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Add Adanos as an optional crypto sentiment source for the existing alt-data signal pipeline.

- polls the read-only Adanos crypto trending endpoint with `X-API-Key`
- feeds Adanos' numeric sentiment score directly into the existing market matcher instead of re-scoring it as keywords
- emits buzz, mention, trend, and bullish/bearish distribution metadata
- deduplicates unchanged snapshots and aborts or invalidates in-flight requests on shutdown
- defaults to a quota-safe three-hour interval (240 requests per 30-day month)
- remains disabled unless both `ALT_DATA_ADANOS_ENABLED=true` and `ADANOS_API_KEY` are configured

Users can create an API key at https://adanos.org/register. API documentation: https://api.adanos.org/docs.

## Testing

- `node --test --import tsx --import ./tests/helpers/test-setup.ts tests/unit/alt-data.test.ts` (20 passed)
- `git diff --check`
- `npm run typecheck` reaches two existing dependency/Open-Prose errors (`ox/tempo/KeyAuthorization.ts` and `src/extensions/open-prose/index.ts`) and reports no Adanos-related errors
- Autoreview: clean, confidence 0.96
