### PR TITLE
feat(feeds): Live Tennis API feed + read-only /tennis skill (vendor-authored)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,10 @@ OPENAI_API_KEY=
 # Twitter/X (for news feeds)
 TWITTER_BEARER_TOKEN=
 
+# Live Tennis API (live tennis scores/fixtures for the /tennis skill)
+# Free key (30 req/min, 100 req/day): https://livetennisapi.com/subscribe/free
+LIVETENNIS_API_KEY=
+
 # SMTP (for email alerts)
 SMTP_HOST=
 SMTP_PORT=587

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node.js">
   <img src="https://img.shields.io/badge/typescript-5.3-blue" alt="TypeScript">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/skills-119%2B-purple" alt="119+ Skills">
+  <img src="https://img.shields.io/badge/skills-120%2B-purple" alt="120+ Skills">
   <img src="https://img.shields.io/badge/markets-1000%2B-orange" alt="1000+ Markets">
   <img src="https://img.shields.io/badge/Colosseum-Agent%20Hackathon-blueviolet" alt="Built for Colosseum Hackathon">
   <img src="https://img.shields.io/badge/clones%2F14d-10.7k-brightgreen" alt="10.7k clones in 14 days">
@@ -142,12 +142,12 @@ See [docs/USER_GUIDE.md](./docs/USER_GUIDE.md) for all commands.
 | **Trading Strategies** | 118+ strategies including momentum, mean reversion, penny clipper, expiry fade, DCA bots, smart routing, whale tracking, copy trading |
 | **Risk Management** | Unified risk engine with circuit breaker, VaR/CVaR, volatility regime detection, stress testing, Kelly sizing, daily loss limits, kill switch |
 | **Backtesting** | Configurable strategy backtesting with historical data, SL/TP validation, P&L analysis |
-| **Skills System** | 119 bundled skills + lazy-loaded extensions (no missing dependencies crash) — chat-driven automation |
+| **Skills System** | 120 bundled skills + lazy-loaded extensions (no missing dependencies crash) — chat-driven automation |
 | **Token Security** | GoPlus-powered audits — honeypot detection, rug-pull analysis, holder concentration, risk scoring |
 | **Security Shield** | Code scanning (75 rules), scam DB (70+ addresses), multi-chain address checking, pre-trade tx validation |
 | **Trading** | Order execution on 16+ platforms (prediction markets, futures, Solana DEXs, EVM DEXs), portfolio tracking, P&L, DCA |
 | **Market Data** | Real-time orderbooks, candles, liquidity tracking, depth analysis, price feeds across all platforms |
-| **MCP Server** | Expose all 119 skills as MCP tools for Claude Desktop and Claude Code |
+| **MCP Server** | Expose all 120 skills as MCP tools for Claude Desktop and Claude Code |
 | **Arbitrage** | Cross-platform detection, combinatorial analysis, semantic matching, real-time scanning |
 | **AI** | 8 LLM providers, 4 specialized agents, semantic memory, 18 tools |
 | **Data Persistence** | SQLite (local), LanceDB (semantic memory + embeddings), PostgreSQL (analytics) — unlimited WebChat history, trade database, context compacting, hybrid search, user profiles |
@@ -365,7 +365,7 @@ Enable: `clodds config set ledger.enabled true`
 ┌──────────────────────────────────────────┴─────────────────────────────────────┐
 │                            AI AGENTS LAYER (4)                                 │
 │  Main (Claude) • Trading (Exec) • Research (Data) • Alerts (Monitor)          │
-│  119+ Skills • 18 Tools • LanceDB Memory • Semantic Reasoning                  │
+│  120+ Skills • 18 Tools • LanceDB Memory • Semantic Reasoning                  │
 └──────────────────────────────────────────┬─────────────────────────────────────┘
                                            │
 ┌──────────────────────────────────────────┴─────────────────────────────────────┐
@@ -617,7 +617,7 @@ docker compose up --build
 | Prediction Markets | **10** |
 | Futures Exchanges | **7** |
 | AI Tools | **18** |
-| Skills | **119** |
+| Skills | **120** |
 | LLM Providers | **8** |
 | Solana DeFi Protocols | **9** |
 | Trading Strategies | **4** |

--- a/docs/SKILLS_CATALOG.md
+++ b/docs/SKILLS_CATALOG.md
@@ -1,4 +1,4 @@
-# Skills Catalog (119 Skills)
+# Skills Catalog (120 Skills)
 
 Complete reference of all bundled skills organized by category. Use `/skills` in chat to browse interactively, or `/skills search <query>` to find skills by keyword.
 
@@ -83,7 +83,7 @@ Complete reference of all bundled skills organized by category. Use `/skills` in
 | edge | `/edge` | Weather market edge calculation |
 | dca | `/dca` | Dollar-cost averaging across platforms |
 
-## Data & Feeds (10 skills)
+## Data & Feeds (11 skills)
 
 | Skill | Command | Description |
 |-------|---------|-------------|
@@ -97,6 +97,7 @@ Complete reference of all bundled skills organized by category. Use `/skills` in
 | analytics | `/analytics` | Opportunity analytics and performance breakdown |
 | metrics | `/metrics` | System health metrics and Prometheus export |
 | weather | `/weather` | NOAA weather data for Polymarket weather markets |
+| livetennis | `/tennis` | Live tennis scores, fixtures and players for tennis event markets |
 
 ## AI & Strategy (15 skills)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -178,7 +178,7 @@ clodds mcp install              # Auto-configure Claude Desktop & Claude Code
 clodds mcp uninstall            # Remove Clodds from Claude config
 ```
 
-Exposes all 119 skills as MCP tools. After `clodds mcp install`, restart Claude Desktop/Code to use Clodds skills directly from Claude.
+Exposes all 120 skills as MCP tools. After `clodds mcp install`, restart Claude Desktop/Code to use Clodds skills directly from Claude.
 
 ### QMD (Quantitative Market Data) Commands
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clodds",
   "version": "1.8.0",
-  "description": "Open-source AI trading terminal. Trade Polymarket, Kalshi, Betfair, Binance, Bybit, Hyperliquid, Solana DEXs from Telegram, Discord, Slack or web. Arbitrage detection, whale tracking, copy trading, perpetual futures up to 200x, DeFi swaps, MEV protection. Self-hosted, 119 skills, powered by Claude.",
+  "description": "Open-source AI trading terminal. Trade Polymarket, Kalshi, Betfair, Binance, Bybit, Hyperliquid, Solana DEXs from Telegram, Discord, Slack or web. Arbitrage detection, whale tracking, copy trading, perpetual futures up to 200x, DeFi swaps, MEV protection. Self-hosted, 120 skills, powered by Claude.",
   "main": "dist/index.js",
   "bin": {
     "clodds": "./dist/cli/index.js"

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -3753,7 +3753,7 @@ export function createOnboardCommand(program: Command): void {
       }
       console.log('');
       console.log(`  ${bold('AI Trading Terminal')} ${dim('for prediction markets, crypto & futures')}`);
-      console.log(`  ${dim('10 markets  \u00b7  21 channels  \u00b7  119 skills')}`);
+      console.log(`  ${dim('10 markets  \u00b7  21 channels  \u00b7  120 skills')}`);
       console.log('');
       console.log(`  ${dim('='.repeat(56))}`);
       console.log('');

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -72,7 +72,7 @@ export const COMMAND_CATEGORIES: Record<string, string | string[]> = {
   markets: 'Market Data', compare: 'Market Data', trending: 'Market Data',
   'market-index': 'Market Data', news: 'Market Data', research: 'Market Data',
   analytics: 'Market Data', ticks: 'Market Data', features: 'Market Data',
-  weather: 'Market Data', stream: 'Market Data',
+  weather: 'Market Data', stream: 'Market Data', livetennis: 'Market Data',
 
   // ── Cross-platform commands → appear under each platform they support ──
   opportunity: ['Market Data', 'Polymarket', 'Kalshi', 'Sportsbooks'],

--- a/src/feeds/descriptors.ts
+++ b/src/feeds/descriptors.ts
@@ -503,6 +503,32 @@ const polymarketRtds: FeedDescriptor = {
 };
 
 // =============================================================================
+// SPORTS DATA
+// =============================================================================
+
+const liveTennis: FeedDescriptor = {
+  id: 'livetennis',
+  name: 'Live Tennis API',
+  description: 'Live tennis scores, fixtures & players (ATP/WTA/Challenger/ITF) — ground truth for tennis event markets',
+  status: 'available',
+  skillCommand: '/tennis',
+  category: 'sports',
+  capabilities: [
+    FeedCapability.SPORTS,
+  ],
+  dataTypes: ['live_scores', 'fixtures', 'players'],
+  connectionType: 'polling',
+  requiredEnv: ['LIVETENNIS_API_KEY'],
+  optionalEnv: [],
+  docsUrl: 'https://docs.livetennisapi.com',
+  version: '1.0.0',
+  create: async () => {
+    const { createLiveTennisFeed } = await import('./livetennis/index');
+    return createLiveTennisFeed() as any;
+  },
+};
+
+// =============================================================================
 // PERPETUAL FUTURES
 // =============================================================================
 
@@ -570,6 +596,9 @@ export function registerAllFeeds(): void {
   registry.register(weatherNWS);
   registry.register(acledConflict);
   registry.register(fredEconomics);
+
+  // Sports data
+  registry.register(liveTennis);
 }
 
 /** Get all descriptor objects for programmatic access. */
@@ -577,5 +606,5 @@ export const allDescriptors: FeedDescriptor[] = [
   polymarket, kalshi, manifold, metaculus, predictit, drift, agentbets,
   betfair, smarkets, opinion, predictfunDesc, hedgehog, virtuals,
   polymarketRtds, percolator, crypto, news, externalData,
-  weatherOpenMeteo, weatherNWS, acledConflict, fredEconomics,
+  weatherOpenMeteo, weatherNWS, acledConflict, fredEconomics, liveTennis,
 ];

--- a/src/feeds/livetennis/index.ts
+++ b/src/feeds/livetennis/index.ts
@@ -1,0 +1,394 @@
+/**
+ * Live Tennis API Feed
+ *
+ * Live tennis scores, upcoming fixtures, and player lookup from the
+ * Live Tennis API (livetennisapi.com) — ATP, WTA, Challenger, ITF and
+ * junior Grand Slam coverage.
+ *
+ * Uses the FREE keyed tier only (30 requests/minute, 100 requests/day):
+ * live scores, upcoming matches, fixtures, and players (including a
+ * player's own current ranking). That quota suits develop-and-test or
+ * ~15-minute-cadence checks, NOT continuous fast polling — responses are
+ * cached in-process (see CACHE TTLS below) so repeated skill/agent calls
+ * don't burn through the daily quota.
+ *
+ * Get a key: https://livetennisapi.com/subscribe/free
+ * API docs:  https://docs.livetennisapi.com
+ */
+
+import { EventEmitter } from 'events';
+import { logger } from '../../utils/logger';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface LiveTennisScore {
+  /** Sets won: [sets_p1, sets_p2] */
+  sets: number[];
+  /** Games per set: [games_p1_per_set[], games_p2_per_set[]] */
+  games: number[][];
+  /** In-game points as tennis strings ("0", "15", "30", "40", "AD"); entries can be null */
+  points: Array<string | null>;
+  /** Which player is serving (1 | 2), or null when unknown */
+  server: 1 | 2 | null;
+  isTiebreak: boolean;
+  /**
+   * Derived, not an API field: the receiver can win this game on the next
+   * point. See isBreakPoint() for the exact rule.
+   */
+  isBreakPoint: boolean;
+  timestamp: Date | null;
+}
+
+export interface LiveTennisPlayer {
+  id: number;
+  name: string;
+  /** Opaque tour string of the record itself (e.g. 'atp', 'challenger_men') */
+  tour: string | null;
+  country: string | null;
+  /** The player's own current ranking (available on the free tier) */
+  ranking: number | null;
+  rankingPoints: number | null;
+  hand: 'R' | 'L' | null;
+  isDoublesTeam: boolean;
+}
+
+export interface LiveTennisMatch {
+  id: number;
+  tournament: string;
+  /** Tour in the filter vocabulary: atp | wta | challenger | itf | juniors, or null */
+  tour: string | null;
+  surface: 'hard' | 'clay' | 'grass' | null;
+  indoor: boolean;
+  format: 'BO3' | 'BO5' | null;
+  round: string | null;
+  status: 'upcoming' | 'live' | 'completed' | 'cancelled';
+  /** singles | doubles | null (null means the feed doesn't know — not singles) */
+  draw: 'singles' | 'doubles' | null;
+  scheduledTime: Date | null;
+  players: { p1: LiveTennisPlayer; p2: LiveTennisPlayer };
+  score: LiveTennisScore | null;
+  /** Completed matches only: 1 | 2 */
+  winner: number | null;
+}
+
+export interface LiveTennisFixture {
+  id: number;
+  eventDate: string | null;
+  /** Scheduled start (UTC); null until the order of play assigns a time */
+  startTime: Date | null;
+  tournament: string | null;
+  round: string | null;
+  surface: string | null;
+  player1Name: string | null;
+  player2Name: string | null;
+  /** Player ids where resolved — null is a real state, not a gap */
+  player1Id: number | null;
+  player2Id: number | null;
+  tour: string | null;
+}
+
+export interface LiveTennisFeed extends EventEmitter {
+  start(): Promise<void>;
+  stop(): void;
+
+  /** Matches currently in play (optionally filtered by tour: atp|wta|challenger|itf|juniors) */
+  getLiveMatches(tour?: string): Promise<LiveTennisMatch[]>;
+
+  /** Matches about to start (same tour filter as getLiveMatches) */
+  getUpcomingMatches(tour?: string): Promise<LiveTennisMatch[]>;
+
+  /** Upcoming scheduled fixtures, earliest first */
+  getFixtures(limit?: number): Promise<LiveTennisFixture[]>;
+
+  /** Search players by name (ranked players first) */
+  searchPlayers(query: string): Promise<LiveTennisPlayer[]>;
+
+  /** One player by id (bio + current ranking) */
+  getPlayer(playerId: number): Promise<LiveTennisPlayer | null>;
+
+  /** One match by id, with its latest score */
+  getMatch(matchId: number): Promise<LiveTennisMatch | null>;
+
+  /** Current score only for a match — lowest-latency REST read */
+  getScore(matchId: number): Promise<LiveTennisScore | null>;
+}
+
+// =============================================================================
+// API HELPERS
+// =============================================================================
+
+const BASE_URL = 'https://api.livetennisapi.com/api/public/v1';
+
+// CACHE TTLS — deliberately conservative for the free tier's 100 req/day.
+const LIVE_TTL_MS = 60_000; // live/upcoming match lists
+const FIXTURES_TTL_MS = 10 * 60_000; // schedules move slowly
+const PLAYER_TTL_MS = 60 * 60_000; // bios/rankings change at most daily
+
+function apiKey(): string {
+  const key = process.env.LIVETENNIS_API_KEY;
+  if (!key) {
+    throw new Error(
+      'LIVETENNIS_API_KEY not set. Get a free key at https://livetennisapi.com/subscribe/free'
+    );
+  }
+  return key;
+}
+
+async function ltFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: {
+      'X-API-Key': apiKey(),
+      Accept: 'application/json',
+    },
+  });
+  if (res.status === 429) {
+    throw new Error(
+      'Live Tennis API rate limit hit (free tier: 30 req/min, 100 req/day)'
+    );
+  }
+  if (res.status === 403) {
+    throw new Error(
+      `Live Tennis API: endpoint above this key's tier (${await res.text()})`
+    );
+  }
+  if (!res.ok) {
+    throw new Error(`Live Tennis API error ${res.status}: ${await res.text()}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Break-point derivation (the API doesn't ship this as a field; it's implied
+ * by the score): the RECEIVER wins the game with the next point — receiver at
+ * AD, or receiver at 40 while the server is at 0/15/30. Never during a
+ * tiebreak, and false when the server or points are unknown.
+ */
+export function isBreakPoint(
+  server: 1 | 2 | null,
+  points: Array<string | null>,
+  isTiebreak: boolean
+): boolean {
+  if (isTiebreak) return false;
+  if (server !== 1 && server !== 2) return false;
+  const serverPoints = points[server - 1];
+  const receiverPoints = points[server === 1 ? 1 : 0];
+  if (serverPoints == null || receiverPoints == null) return false;
+  if (receiverPoints === 'AD') return true;
+  return receiverPoints === '40' && ['0', '15', '30'].includes(serverPoints);
+}
+
+// =============================================================================
+// RESPONSE MAPPING
+// =============================================================================
+
+interface ApiScore {
+  sets?: number[];
+  games?: number[][];
+  points?: Array<string | null>;
+  server?: 1 | 2 | null;
+  is_tiebreak?: boolean;
+  timestamp?: string | null;
+}
+
+interface ApiPlayer {
+  id: number;
+  name: string;
+  tour?: string | null;
+  country?: string | null;
+  ranking?: number | null;
+  ranking_points?: number | null;
+  hand?: 'R' | 'L' | null;
+  is_doubles_team?: boolean;
+}
+
+interface ApiMatch {
+  id: number;
+  tournament: string;
+  tour?: string | null;
+  surface?: 'hard' | 'clay' | 'grass' | null;
+  indoor?: boolean;
+  format?: 'BO3' | 'BO5' | null;
+  round?: string | null;
+  status: 'upcoming' | 'live' | 'completed' | 'cancelled';
+  draw?: 'singles' | 'doubles' | null;
+  scheduled_time?: string | null;
+  players?: { p1?: ApiPlayer; p2?: ApiPlayer };
+  score?: ApiScore | null;
+  winner?: number | null;
+}
+
+interface ApiFixture {
+  id: number;
+  event_date?: string | null;
+  start_time?: string | null;
+  tournament?: string | null;
+  round?: string | null;
+  surface?: string | null;
+  player1_name?: string | null;
+  player2_name?: string | null;
+  player1_id?: number | null;
+  player2_id?: number | null;
+  tour?: string | null;
+}
+
+export function mapScore(s: ApiScore | null | undefined): LiveTennisScore | null {
+  if (!s) return null;
+  const server = s.server ?? null;
+  const points = s.points ?? [];
+  const isTiebreak = s.is_tiebreak ?? false;
+  return {
+    sets: s.sets ?? [],
+    games: s.games ?? [],
+    points,
+    server,
+    isTiebreak,
+    isBreakPoint: isBreakPoint(server, points, isTiebreak),
+    timestamp: s.timestamp ? new Date(s.timestamp) : null,
+  };
+}
+
+function mapPlayer(p: ApiPlayer): LiveTennisPlayer {
+  return {
+    id: p.id,
+    name: p.name,
+    tour: p.tour ?? null,
+    country: p.country ?? null,
+    ranking: p.ranking ?? null,
+    rankingPoints: p.ranking_points ?? null,
+    hand: p.hand ?? null,
+    isDoublesTeam: p.is_doubles_team ?? false,
+  };
+}
+
+const UNKNOWN_PLAYER: ApiPlayer = { id: 0, name: 'Unknown' };
+
+function mapMatch(m: ApiMatch): LiveTennisMatch {
+  return {
+    id: m.id,
+    tournament: m.tournament,
+    tour: m.tour ?? null,
+    surface: m.surface ?? null,
+    indoor: m.indoor ?? false,
+    format: m.format ?? null,
+    round: m.round ?? null,
+    status: m.status,
+    draw: m.draw ?? null,
+    scheduledTime: m.scheduled_time ? new Date(m.scheduled_time) : null,
+    players: {
+      p1: mapPlayer(m.players?.p1 ?? UNKNOWN_PLAYER),
+      p2: mapPlayer(m.players?.p2 ?? UNKNOWN_PLAYER),
+    },
+    score: mapScore(m.score),
+    winner: m.winner ?? null,
+  };
+}
+
+function mapFixture(f: ApiFixture): LiveTennisFixture {
+  return {
+    id: f.id,
+    eventDate: f.event_date ?? null,
+    startTime: f.start_time ? new Date(f.start_time) : null,
+    tournament: f.tournament ?? null,
+    round: f.round ?? null,
+    surface: f.surface ?? null,
+    player1Name: f.player1_name ?? null,
+    player2Name: f.player2_name ?? null,
+    player1Id: f.player1_id ?? null,
+    player2Id: f.player2_id ?? null,
+    tour: f.tour ?? null,
+  };
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+export async function createLiveTennisFeed(): Promise<LiveTennisFeed> {
+  const emitter = new EventEmitter() as LiveTennisFeed;
+
+  // Tiny TTL cache so agent chatter doesn't burn the 100/day free quota.
+  const cache = new Map<string, { expires: number; value: unknown }>();
+
+  async function cached<T>(key: string, ttlMs: number, load: () => Promise<T>): Promise<T> {
+    const hit = cache.get(key);
+    if (hit && hit.expires > Date.now()) return hit.value as T;
+    const value = await load();
+    cache.set(key, { expires: Date.now() + ttlMs, value });
+    return value;
+  }
+
+  emitter.start = async () => {
+    logger.info('Live Tennis API feed started');
+  };
+
+  emitter.stop = () => {
+    cache.clear();
+    logger.info('Live Tennis API feed stopped');
+  };
+
+  const listMatches = async (status: 'live' | 'upcoming', tour?: string) => {
+    const tourParam = tour ? `&tour=${encodeURIComponent(tour)}` : '';
+    return cached(`matches:${status}:${tour ?? ''}`, LIVE_TTL_MS, async () => {
+      const data = await ltFetch<{ data: ApiMatch[] }>(
+        `/matches?status=${status}${tourParam}`
+      );
+      return data.data.map(mapMatch);
+    });
+  };
+
+  emitter.getLiveMatches = (tour?: string) => listMatches('live', tour);
+  emitter.getUpcomingMatches = (tour?: string) => listMatches('upcoming', tour);
+
+  emitter.getFixtures = async (limit = 20): Promise<LiveTennisFixture[]> => {
+    return cached(`fixtures:${limit}`, FIXTURES_TTL_MS, async () => {
+      const data = await ltFetch<{ data: ApiFixture[] }>(`/fixtures?limit=${limit}`);
+      return data.data.map(mapFixture);
+    });
+  };
+
+  emitter.searchPlayers = async (query: string): Promise<LiveTennisPlayer[]> => {
+    return cached(`players:${query.toLowerCase()}`, PLAYER_TTL_MS, async () => {
+      const data = await ltFetch<{ data: ApiPlayer[] }>(
+        `/players?search=${encodeURIComponent(query)}`
+      );
+      return data.data.map(mapPlayer);
+    });
+  };
+
+  emitter.getPlayer = async (playerId: number): Promise<LiveTennisPlayer | null> => {
+    try {
+      return await cached(`player:${playerId}`, PLAYER_TTL_MS, async () => {
+        const p = await ltFetch<ApiPlayer>(`/players/${playerId}`);
+        return mapPlayer(p);
+      });
+    } catch (error) {
+      logger.warn({ error, playerId }, 'Live Tennis API player lookup failed');
+      return null;
+    }
+  };
+
+  emitter.getMatch = async (matchId: number): Promise<LiveTennisMatch | null> => {
+    try {
+      // No cache: a single match read is usually a "what's the score NOW" ask.
+      const m = await ltFetch<ApiMatch>(`/matches/${matchId}`);
+      return mapMatch(m);
+    } catch (error) {
+      logger.warn({ error, matchId }, 'Live Tennis API match lookup failed');
+      return null;
+    }
+  };
+
+  emitter.getScore = async (matchId: number): Promise<LiveTennisScore | null> => {
+    try {
+      const s = await ltFetch<ApiScore>(`/matches/${matchId}/score`);
+      return mapScore(s);
+    } catch (error) {
+      logger.warn({ error, matchId }, 'Live Tennis API score lookup failed');
+      return null;
+    }
+  };
+
+  return emitter;
+}

--- a/src/skills/bundled/livetennis/SKILL.md
+++ b/src/skills/bundled/livetennis/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: livetennis
+description: "Live tennis scores, fixtures and player lookup — match-state ground truth for tennis event markets"
+command: tennis
+emoji: "🎾"
+gates:
+  envs:
+    - LIVETENNIS_API_KEY
+---
+
+# Live Tennis
+
+Live tennis scores, upcoming fixtures, and player lookup from the
+Live Tennis API (livetennisapi.com) — ATP, WTA, Challenger, ITF and junior
+Grand Slam coverage. Useful as match-state ground truth when reasoning about
+tennis event markets on Polymarket, Kalshi or Betfair: the score object says
+who is serving, the set/game state, and whether the current point is a
+break point.
+
+## Commands
+
+```
+/tennis live [tour]        Matches in play (tour: atp|wta|challenger|itf|juniors)
+/tennis upcoming [tour]    Matches about to start
+/tennis fixtures [n]       Upcoming scheduled fixtures, earliest first
+/tennis player <name>      Player lookup (bio + current ranking)
+/tennis match <id>         One match with its latest score
+```
+
+## Examples
+
+```
+/tennis live atp
+/tennis upcoming wta
+/tennis fixtures 15
+/tennis player Alcaraz
+/tennis match 12345
+```
+
+## Setup
+
+Set `LIVETENNIS_API_KEY`. A free key (no card) is available at
+https://livetennisapi.com/subscribe/free — API docs at
+https://docs.livetennisapi.com
+
+## Rate Limits (free tier)
+
+30 requests/minute, 100 requests/day. That suits develop-and-test or
+~15-minute-cadence checks, **not** continuous fast polling. The feed caches
+responses in-process (live matches 60s, fixtures 10m, players 1h) so
+repeated calls don't burn the daily quota.
+
+## Notes for the Agent
+
+- Match ids from `/tennis live`, `/tennis upcoming` and `/tennis fixtures`
+  work with `/tennis match <id>`.
+- "break point" in the output is derived from the score (receiver at AD, or
+  receiver at 40 with the server at 0/15/30; never during tiebreaks).
+- A player's own current ranking is included on the free tier; the
+  rank-ordered top-N rankings listing is a paid endpoint and is not exposed
+  by this skill.
+- This skill is read-only market context; it places no orders.

--- a/src/skills/bundled/livetennis/index.ts
+++ b/src/skills/bundled/livetennis/index.ts
@@ -1,0 +1,286 @@
+/**
+ * Live Tennis Skill - live scores, fixtures & player lookup
+ *
+ * Match-state ground truth for tennis event markets (Polymarket, Kalshi,
+ * Betfair all run tennis match-winner markets), backed by the Live Tennis
+ * API's free keyed tier.
+ *
+ * Commands:
+ * /tennis live [tour]        Matches in play right now
+ * /tennis upcoming [tour]    Matches about to start
+ * /tennis fixtures [n]       Upcoming scheduled fixtures
+ * /tennis player <name>      Player lookup (bio + current ranking)
+ * /tennis match <id>         One match with its latest score
+ */
+
+import type {
+  LiveTennisFeed,
+  LiveTennisMatch,
+  LiveTennisFixture,
+  LiveTennisPlayer,
+  LiveTennisScore,
+} from '../../../feeds/livetennis/index';
+
+const TOURS = ['atp', 'wta', 'challenger', 'itf', 'juniors'];
+
+// Lazily created feed (module-level so the TTL cache survives across calls)
+let feed: LiveTennisFeed | null = null;
+
+async function getFeed(): Promise<LiveTennisFeed> {
+  if (!feed) {
+    const { createLiveTennisFeed } = await import('../../../feeds/livetennis/index');
+    feed = await createLiveTennisFeed();
+  }
+  return feed;
+}
+
+function formatScore(score: LiveTennisScore | null, p1: string, p2: string): string {
+  if (!score) return '  _no score yet_';
+
+  const setsLine = (score.games[0] || [])
+    .map((g1, i) => `${g1}-${score.games[1]?.[i] ?? 0}`)
+    .join(' ');
+
+  let output = `  Sets: ${score.sets[0] ?? 0}-${score.sets[1] ?? 0}`;
+  if (setsLine) output += ` (${setsLine})`;
+
+  const [pts1, pts2] = score.points;
+  if (pts1 != null && pts2 != null) {
+    output += ` | ${score.isTiebreak ? 'Tiebreak' : 'Points'}: ${pts1}-${pts2}`;
+  }
+
+  if (score.server === 1 || score.server === 2) {
+    output += ` | Serving: ${score.server === 1 ? p1 : p2}`;
+  }
+  if (score.isBreakPoint) {
+    output += ' | **break point**';
+  }
+  return output;
+}
+
+function formatMatch(match: LiveTennisMatch): string {
+  const p1 = match.players.p1.name;
+  const p2 = match.players.p2.name;
+
+  let output = `**${p1} vs ${p2}**\n`;
+  output += `  ${match.tournament}`;
+  if (match.round) output += ` | ${match.round}`;
+  if (match.surface) output += ` | ${match.surface}${match.indoor ? ' (indoor)' : ''}`;
+  if (match.tour) output += ` | ${match.tour.toUpperCase()}`;
+  output += `\n  ID: \`${match.id}\` | Status: ${match.status}`;
+  if (match.status === 'completed' && match.winner) {
+    output += ` | Winner: ${match.winner === 1 ? p1 : p2}`;
+  }
+  output += '\n';
+  output += formatScore(match.score, p1, p2);
+  return output;
+}
+
+function formatFixture(fixture: LiveTennisFixture): string {
+  const when = fixture.startTime
+    ? fixture.startTime.toISOString().replace('T', ' ').slice(0, 16) + ' UTC'
+    : fixture.eventDate || 'TBD';
+
+  let output = `**${fixture.player1Name || '?'} vs ${fixture.player2Name || '?'}**\n`;
+  output += `  ${when}`;
+  if (fixture.tournament) output += ` | ${fixture.tournament}`;
+  if (fixture.round) output += ` | ${fixture.round}`;
+  if (fixture.surface) output += ` | ${fixture.surface}`;
+  return output;
+}
+
+function formatPlayer(player: LiveTennisPlayer): string {
+  let output = `**${player.name}**`;
+  if (player.country) output += ` (${player.country})`;
+  output += '\n';
+  output += `  ID: \`${player.id}\``;
+  if (player.ranking != null) {
+    output += ` | Ranking: #${player.ranking}`;
+    if (player.rankingPoints != null) output += ` (${player.rankingPoints} pts)`;
+  }
+  if (player.tour) output += ` | Tour: ${player.tour}`;
+  if (player.hand) output += ` | ${player.hand === 'R' ? 'Right' : 'Left'}-handed`;
+  if (player.isDoublesTeam) output += ' | doubles team';
+  return output;
+}
+
+function parseTour(args: string[]): { tour?: string; error?: string } {
+  if (args.length === 0) return {};
+  const tour = args[0].toLowerCase();
+  if (!TOURS.includes(tour)) {
+    return { error: `Unknown tour: ${args[0]}\n\nSupported tours: ${TOURS.join(', ')}` };
+  }
+  return { tour };
+}
+
+async function handleMatches(kind: 'live' | 'upcoming', args: string[]): Promise<string> {
+  const { tour, error } = parseTour(args);
+  if (error) return error;
+
+  try {
+    const tennis = await getFeed();
+    const matches = kind === 'live'
+      ? await tennis.getLiveMatches(tour)
+      : await tennis.getUpcomingMatches(tour);
+
+    if (matches.length === 0) {
+      return kind === 'live'
+        ? `No matches in play right now${tour ? ` on ${tour.toUpperCase()}` : ''}.`
+        : `No upcoming matches found${tour ? ` on ${tour.toUpperCase()}` : ''}.`;
+    }
+
+    const title = kind === 'live' ? 'Live Tennis Matches' : 'Upcoming Tennis Matches';
+    let output = `**${title} (${matches.length})**\n\n`;
+    for (const match of matches.slice(0, 10)) {
+      output += formatMatch(match) + '\n\n';
+    }
+    if (matches.length > 10) {
+      output += `_...and ${matches.length - 10} more_`;
+    }
+    return output;
+  } catch (error) {
+    return `Failed to fetch matches: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+async function handleFixtures(args: string[]): Promise<string> {
+  let limit = 10;
+  if (args[0]) {
+    const parsed = parseInt(args[0], 10);
+    if (!isNaN(parsed) && parsed > 0) limit = Math.min(parsed, 50);
+  }
+
+  try {
+    const tennis = await getFeed();
+    const fixtures = await tennis.getFixtures(limit);
+
+    if (fixtures.length === 0) {
+      return 'No scheduled fixtures found.';
+    }
+
+    let output = `**Upcoming Fixtures (${fixtures.length})**\n\n`;
+    for (const fixture of fixtures) {
+      output += formatFixture(fixture) + '\n\n';
+    }
+    return output;
+  } catch (error) {
+    return `Failed to fetch fixtures: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+async function handlePlayer(args: string[]): Promise<string> {
+  if (args.length === 0) {
+    return 'Usage: /tennis player <name>\n\nExample: /tennis player Alcaraz';
+  }
+
+  const query = args.join(' ').replace(/"/g, '');
+
+  try {
+    const tennis = await getFeed();
+    const players = await tennis.searchPlayers(query);
+
+    if (players.length === 0) {
+      return `No players found matching "${query}".`;
+    }
+
+    let output = `**Players matching "${query}" (${players.length})**\n\n`;
+    for (const player of players.slice(0, 8)) {
+      output += formatPlayer(player) + '\n\n';
+    }
+    if (players.length > 8) {
+      output += `_...and ${players.length - 8} more_`;
+    }
+    return output;
+  } catch (error) {
+    return `Player search failed: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+async function handleMatch(args: string[]): Promise<string> {
+  const matchId = parseInt(args[0] ?? '', 10);
+  if (isNaN(matchId)) {
+    return 'Usage: /tennis match <id>\n\nGet ids from `/tennis live` or `/tennis upcoming`.';
+  }
+
+  try {
+    const tennis = await getFeed();
+    const match = await tennis.getMatch(matchId);
+
+    if (!match) {
+      return `Match not found: ${matchId}`;
+    }
+    return formatMatch(match);
+  } catch (error) {
+    return `Failed to fetch match: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+export async function execute(args: string): Promise<string> {
+  const parts = args.trim().split(/\s+/).filter(Boolean);
+  const command = parts[0]?.toLowerCase() || 'help';
+  const rest = parts.slice(1);
+
+  switch (command) {
+    case 'live':
+    case 'l':
+      return handleMatches('live', rest);
+
+    case 'upcoming':
+    case 'u':
+      return handleMatches('upcoming', rest);
+
+    case 'fixtures':
+    case 'fix':
+    case 'f':
+      return handleFixtures(rest);
+
+    case 'player':
+    case 'p':
+      return handlePlayer(rest);
+
+    case 'match':
+    case 'm':
+      return handleMatch(rest);
+
+    case 'help':
+    default:
+      return `**Live Tennis**
+
+Live scores, fixtures and player lookup — match-state ground truth for
+tennis event markets (Polymarket, Kalshi and Betfair all list tennis
+match-winner markets).
+
+**Commands:**
+\`\`\`
+/tennis live [tour]        Matches in play (tour: atp|wta|challenger|itf|juniors)
+/tennis upcoming [tour]    Matches about to start
+/tennis fixtures [n]       Upcoming scheduled fixtures
+/tennis player <name>      Player lookup (bio + current ranking)
+/tennis match <id>         One match with its latest score
+\`\`\`
+
+**Example Workflow:**
+\`\`\`
+/tennis live atp
+/tennis match 12345
+/tennis player Alcaraz
+\`\`\`
+
+**Setup:**
+Set LIVETENNIS_API_KEY — free key (no card) from
+https://livetennisapi.com/subscribe/free
+
+**Free-tier limits (honest numbers):** 30 requests/minute, 100 requests/day.
+Good for develop-and-test or ~15-minute-cadence checks, not continuous fast
+polling. Responses are cached in-process (live: 60s, fixtures: 10m,
+players: 1h) to stretch the quota.`;
+  }
+}
+
+export default {
+  name: 'livetennis',
+  description: 'Live tennis scores, fixtures and player lookup — match-state ground truth for tennis event markets',
+  commands: ['/tennis'],
+  requires: { env: ['LIVETENNIS_API_KEY'] },
+  handle: execute,
+};

--- a/src/skills/executor.ts
+++ b/src/skills/executor.ts
@@ -1,5 +1,5 @@
 /**
- * Skill Executor - Central registry for all 119 bundled CLI skill handlers.
+ * Skill Executor - Central registry for all 120 bundled CLI skill handlers.
  *
  * ARCHITECTURE:
  * - Each skill lives in src/skills/bundled/<name>/index.ts
@@ -78,6 +78,7 @@ const SKILL_MANIFEST: string[] = [
   'kamino',
   'ledger',
   'lighter',
+  'livetennis',
   'marginfi',
   'market-index',
   // 'markets', // removed: stub returning fake data, use market-index instead
@@ -251,6 +252,7 @@ const SKILL_CATEGORIES: Record<string, SkillCategory> = {
   'analytics': 'Data & Feeds',
   'metrics': 'Data & Feeds',
   'weather': 'Data & Feeds',
+  'livetennis': 'Data & Feeds',
 
   // AI & Strategy
   'ai-strategy': 'AI & Strategy',

--- a/src/skills/help.ts
+++ b/src/skills/help.ts
@@ -1,7 +1,7 @@
 /**
  * Standardized Help System for Skills
  *
- * Provides consistent help output format across all 119 skills.
+ * Provides consistent help output format across all 120 skills.
  * Skills call formatHelp() in their default/help case.
  */
 

--- a/tests/unit/feeds/livetennis.test.ts
+++ b/tests/unit/feeds/livetennis.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Live Tennis API Feed Tests
+ *
+ * Unit tests for the pure logic: break-point derivation and response mapping.
+ * No network calls.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isBreakPoint, mapScore } from '../../../src/feeds/livetennis/index';
+
+// =============================================================================
+// BREAK-POINT DERIVATION
+// =============================================================================
+
+describe('livetennis isBreakPoint', () => {
+  it('receiver at AD against serve is a break point', () => {
+    // p1 serving, p2 (receiver) at AD
+    assert.equal(isBreakPoint(1, ['40', 'AD'], false), true);
+    // p2 serving, p1 (receiver) at AD
+    assert.equal(isBreakPoint(2, ['AD', '40'], false), true);
+  });
+
+  it('receiver at 40 with server at 0/15/30 is a break point', () => {
+    assert.equal(isBreakPoint(1, ['0', '40'], false), true);
+    assert.equal(isBreakPoint(1, ['15', '40'], false), true);
+    assert.equal(isBreakPoint(1, ['30', '40'], false), true);
+    assert.equal(isBreakPoint(2, ['40', '30'], false), true);
+  });
+
+  it('deuce (40-40) is not a break point', () => {
+    assert.equal(isBreakPoint(1, ['40', '40'], false), false);
+  });
+
+  it('server at AD is not a break point', () => {
+    assert.equal(isBreakPoint(1, ['AD', '40'], false), false);
+  });
+
+  it('receiver below 40 is not a break point', () => {
+    assert.equal(isBreakPoint(1, ['0', '30'], false), false);
+    assert.equal(isBreakPoint(1, ['40', '15'], false), false);
+  });
+
+  it('never a break point during a tiebreak', () => {
+    assert.equal(isBreakPoint(1, ['0', '40'], true), false);
+  });
+
+  it('false when server is unknown', () => {
+    assert.equal(isBreakPoint(null, ['0', '40'], false), false);
+  });
+
+  it('false when either points entry is null', () => {
+    assert.equal(isBreakPoint(1, [null, '40'], false), false);
+    assert.equal(isBreakPoint(1, ['30', null], false), false);
+    assert.equal(isBreakPoint(1, [], false), false);
+  });
+});
+
+// =============================================================================
+// RESPONSE MAPPING
+// =============================================================================
+
+describe('livetennis mapScore', () => {
+  it('maps a live score and derives the break-point flag', () => {
+    const score = mapScore({
+      sets: [1, 0],
+      games: [[6, 3], [4, 5]],
+      points: ['15', '40'],
+      server: 1,
+      is_tiebreak: false,
+      timestamp: '2026-08-18T12:00:00Z',
+    });
+
+    assert.ok(score);
+    assert.deepEqual(score.sets, [1, 0]);
+    assert.equal(score.server, 1);
+    assert.equal(score.isTiebreak, false);
+    assert.equal(score.isBreakPoint, true);
+    assert.ok(score.timestamp instanceof Date);
+  });
+
+  it('returns null for a missing score (upcoming match)', () => {
+    assert.equal(mapScore(null), null);
+    assert.equal(mapScore(undefined), null);
+  });
+
+  it('tolerates null points entries observed on completed matches', () => {
+    const score = mapScore({
+      sets: [2, 0],
+      games: [],
+      points: [null, null],
+      server: null,
+      is_tiebreak: false,
+      timestamp: null,
+    });
+
+    assert.ok(score);
+    assert.equal(score.isBreakPoint, false);
+    assert.equal(score.timestamp, null);
+  });
+});


### PR DESCRIPTION
**Vendor disclosure up front:** I run the Live Tennis API (livetennisapi.com), so this feed is vendor-authored — judge accordingly. Everything below follows the repo's documented feed pattern and ships with tests; nothing requires a paid plan.

## What this adds

A new sports data feed + read-only skill, built per the "To add a new feed" instructions in `src/feeds/descriptors.ts` and modeled on the `weather-nws` feed (an existing non-venue ground-truth feed):

- **`src/feeds/livetennis/index.ts`** — live scores, upcoming matches, scheduled fixtures, and player lookup (bio + the player's own current ranking) across ATP / WTA / Challenger / ITF / junior Grand Slams. Same EventEmitter-factory shape as `createNWSFeed`.
- **Descriptor + registration** in `src/feeds/descriptors.ts` under a new SPORTS DATA section: category `sports`, `FeedCapability.SPORTS`, `connectionType: 'polling'`, `requiredEnv: ['LIVETENNIS_API_KEY']` — so it shows up in `/feeds list` with the usual ready/missing-env handling.
- **`/tennis` skill** (`src/skills/bundled/livetennis/`) — `live | upcoming | fixtures | player | match`, wired into `SKILL_MANIFEST`, skill/command categories, and `docs/SKILLS_CATALOG.md` (counts bumped 119 → 120 everywhere they're stated). Read-only market context: it places no orders.
- **`.env.example`** — `LIVETENNIS_API_KEY` with the free-key link.
- **`tests/unit/feeds/livetennis.test.ts`** — unit tests for the pure logic (break-point derivation + response mapping), no network.

Why it fits: Polymarket, Kalshi and Betfair all list tennis match-winner markets, and CloddsBot already ingests non-venue ground truth (weather, FRED, ACLED, news) to inform market decisions. A live tennis match-state feed is the same shape — the score object says who's serving, the set/game state, and whether the current point is a break point (derived: receiver at AD, or receiver at 40 with the server at 0/15/30; never during tiebreaks).

## Honest tier statement

The feed uses the **free keyed tier only**: live scores, upcoming matches, fixtures, players — **30 requests/minute, 100 requests/day**, no card required (https://livetennisapi.com/subscribe/free). That quota suits develop-and-test or ~15-minute-cadence checks, **not** continuous fast polling, so the feed carries an in-process TTL cache (live 60s / fixtures 10m / players 1h) to keep agent chatter from burning the daily quota. Historical results, market prices and the WebSocket stream are paid endpoints and are deliberately **not** exposed here. Docs: https://docs.livetennisapi.com

## Checks

- `npm run typecheck` — clean
- `npm test` — 135/135 pass (11 of those are the new livetennis tests)
- `npm run build` — green; `dist/feeds/livetennis` + `dist/skills/bundled/livetennis` (incl. SKILL.md copy) produced

Happy to adjust naming, category placement, or drop the skill and keep just the feed if you'd rather keep the surface smaller.
