### PR TITLE
feat: add Atlas Cloud TTS provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,12 @@ TEAMS_APP_PASSWORD=
 # OpenAI (for embeddings if preferred over local)
 OPENAI_API_KEY=
 
+# TTS (ElevenLabs is the default provider)
+ELEVENLABS_API_KEY=
+# To use Atlas Cloud TTS instead:
+# CLODDS_TTS_PROVIDER=atlas
+# ATLASCLOUD_API_KEY=
+
 # Twitter/X (for news feeds)
 TWITTER_BEARER_TOKEN=
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -273,7 +273,7 @@ export interface BrowserConfig {
 
 export interface TTSConfig {
   enabled?: boolean;
-  provider?: 'elevenlabs' | 'system';
+  provider?: 'elevenlabs' | 'atlas' | 'system';
   voice?: string;
   apiKey?: string;
 }
@@ -655,6 +655,13 @@ const ENV_MAPPINGS: Record<string, (cfg: CloddsConfig) => void> = {
   OPENAI_API_KEY: () => {},
   ELEVENLABS_API_KEY: (cfg) => {
     if (cfg.tts) cfg.tts.apiKey = process.env.ELEVENLABS_API_KEY;
+  },
+  ATLASCLOUD_API_KEY: () => {},
+  CLODDS_TTS_PROVIDER: (cfg) => {
+    const provider = process.env.CLODDS_TTS_PROVIDER;
+    if (cfg.tts && (provider === 'elevenlabs' || provider === 'atlas')) {
+      cfg.tts.provider = provider;
+    }
   },
   TELEGRAM_BOT_TOKEN: (cfg) => {
     if (!cfg.channels) cfg.channels = {};

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -583,6 +583,8 @@ export function createServer(
         { key: 'FIREWORKS_API_KEY', label: 'Fireworks API Key', secret: true, required: false },
         { key: 'TOGETHER_API_KEY', label: 'Together API Key', secret: true, required: false },
         { key: 'ELEVENLABS_API_KEY', label: 'ElevenLabs API Key', secret: true, required: false },
+        { key: 'ATLASCLOUD_API_KEY', label: 'Atlas Cloud API Key', secret: true, required: false },
+        { key: 'CLODDS_TTS_PROVIDER', label: 'TTS Provider (elevenlabs or atlas)', secret: false, required: false },
         { key: 'VOYAGE_API_KEY', label: 'Voyage API Key', secret: true, required: false },
       ],
     },

--- a/src/skills/bundled/tts/SKILL.md
+++ b/src/skills/bundled/tts/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: tts
-description: "Text-to-speech synthesis with ElevenLabs and system voices"
+description: "Text-to-speech synthesis with ElevenLabs or Atlas Cloud"
 emoji: "🔊"
 gates:
   envs:
     anyOf:
       - ELEVENLABS_API_KEY
+      - ATLASCLOUD_API_KEY
 ---
 
 # TTS (Text-to-Speech) - Complete API Reference
 
-Convert text to natural-sounding speech using ElevenLabs, macOS say, or espeak.
+Convert text to natural-sounding speech using ElevenLabs or Atlas Cloud.
+
+ElevenLabs remains the default. To opt into Atlas Cloud, set
+`CLODDS_TTS_PROVIDER=atlas` and `ATLASCLOUD_API_KEY`.
 
 ---
 
@@ -53,11 +57,6 @@ import { createTTSService } from 'clodds/tts';
 const tts = createTTSService({
   provider: 'elevenlabs',
   apiKey: process.env.ELEVENLABS_API_KEY,
-
-  // Defaults
-  defaultVoice: 'rachel',
-  defaultSpeed: 1.0,
-  defaultPitch: 1.0,
 });
 ```
 
@@ -157,6 +156,7 @@ tts.skip();
 | Provider | Quality | Latency | Cost | Setup |
 |----------|---------|---------|------|-------|
 | **ElevenLabs** | Premium | ~500ms | $5/100k chars | API key |
+| **Atlas Cloud** | Premium | Async | Usage based | API key |
 | **say** (macOS) | Good | ~100ms | Free | Built-in |
 | **espeak** | Basic | ~50ms | Free | Install |
 
@@ -167,6 +167,12 @@ tts.skip();
 const tts = createTTSService({
   provider: 'elevenlabs',
   apiKey: process.env.ELEVENLABS_API_KEY,
+});
+
+// Atlas Cloud (optional; uses elevenlabs/v3/text-to-speech)
+const atlasTts = createTTSService({
+  provider: 'atlas',
+  apiKey: process.env.ATLASCLOUD_API_KEY,
 });
 
 // macOS say (free, local)

--- a/src/skills/bundled/tts/index.ts
+++ b/src/skills/bundled/tts/index.ts
@@ -2,7 +2,7 @@
  * TTS CLI Skill
  *
  * Commands:
- * /tts <text> - Speak text via ElevenLabs
+ * /tts <text> - Speak text via the configured TTS provider
  * /tts voices - List available voices
  * /tts config - Show TTS config and availability
  */
@@ -18,15 +18,17 @@ async function execute(args: string): Promise<string> {
     const { createTTSService } = await import('../../../tts/index');
 
     const tts = createTTSService();
+    const engine = tts.provider === 'atlas' ? 'Atlas Cloud' : 'ElevenLabs';
+    const apiKeyName = tts.provider === 'atlas' ? 'ATLASCLOUD_API_KEY' : 'ELEVENLABS_API_KEY';
 
     switch (cmd) {
       case 'voices': {
         if (!tts.isAvailable()) {
-          return '**TTS Voices**\n\nTTS not configured. Set ELEVENLABS_API_KEY environment variable.';
+          return `**TTS Voices**\n\nTTS not configured. Set ${apiKeyName} environment variable.`;
         }
         const voices = await tts.listVoices();
         if (voices.length === 0) {
-          return '**TTS Voices**\n\nNo voices returned from ElevenLabs API. Check your API key.';
+          return `**TTS Voices**\n\nNo voices returned from ${engine}. Check your API key.`;
         }
         const lines = voices.map(v => {
           const preview = v.preview_url ? ` [preview](${v.preview_url})` : '';
@@ -38,13 +40,15 @@ async function execute(args: string): Promise<string> {
       case 'config':
       case 'status': {
         const available = tts.isAvailable();
-        const voiceDisplay = ttsPrefs.voice || 'Bella (EXAVITQu4vr4xnSDxMaL)';
+        const voiceDisplay = ttsPrefs.voice || (
+          tts.provider === 'atlas' ? 'provider default' : 'Bella (EXAVITQu4vr4xnSDxMaL)'
+        );
         const stabilityDisplay = ttsPrefs.stability ?? 0.5;
         return `**TTS Config**\n\n` +
-          `Engine: ElevenLabs\n` +
-          `Available: ${available ? 'Yes' : 'No (set ELEVENLABS_API_KEY)'}\n` +
+          `Engine: ${engine}\n` +
+          `Available: ${available ? 'Yes' : `No (set ${apiKeyName})`}\n` +
           `Voice: ${voiceDisplay}\n` +
-          `Default model: eleven_monolingual_v1\n` +
+          `Default model: ${tts.provider === 'atlas' ? 'elevenlabs/v3/text-to-speech' : 'eleven_monolingual_v1'}\n` +
           `Stability: ${stabilityDisplay}\n` +
           `Similarity boost: 0.75`;
       }
@@ -74,7 +78,7 @@ async function execute(args: string): Promise<string> {
       }
 
       case 'help':
-        return helpText();
+        return helpText(engine);
 
       default: {
         // Everything else is text to speak
@@ -82,7 +86,7 @@ async function execute(args: string): Promise<string> {
         if (!text) return 'Usage: /tts <text>';
 
         if (!tts.isAvailable()) {
-          return 'TTS not configured. Set ELEVENLABS_API_KEY environment variable.';
+          return `TTS not configured. Set ${apiKeyName} environment variable.`;
         }
 
         // Parse optional --voice flag (overrides session default)
@@ -97,7 +101,7 @@ async function execute(args: string): Promise<string> {
         return `**TTS Synthesized**\n\n` +
           `Text: "${cleanText.slice(0, 100)}${cleanText.length > 100 ? '...' : ''}"\n` +
           `Audio size: ${(buffer.length / 1024).toFixed(1)} KB\n` +
-          `Voice: ${voiceId || 'default (Bella)'}`;
+          `Voice: ${voiceId || (tts.provider === 'atlas' ? 'provider default' : 'default (Bella)')}`;
       }
     }
   } catch (error) {
@@ -105,10 +109,10 @@ async function execute(args: string): Promise<string> {
   }
 }
 
-function helpText(): string {
+function helpText(engine: string): string {
   return `**TTS Commands**
 
-  /tts <text>                        - Speak text via ElevenLabs
+  /tts <text>                        - Speak text via ${engine}
   /tts <text> --voice <id>           - Speak with specific voice
   /tts voices                        - List available voices
   /tts config                        - Show TTS config
@@ -118,7 +122,7 @@ function helpText(): string {
 
 export default {
   name: 'tts',
-  description: 'Text-to-speech synthesis with ElevenLabs and system voices',
+  description: 'Text-to-speech synthesis with ElevenLabs or Atlas Cloud',
   commands: ['/tts', '/speak'],
   handle: execute,
 };

--- a/src/tts/index.ts
+++ b/src/tts/index.ts
@@ -2,13 +2,11 @@
  * TTS (Text-to-Speech) - Clawdbot-style voice synthesis
  *
  * Features:
- * - ElevenLabs integration
+ * - ElevenLabs and Atlas Cloud integrations
  * - Voice selection
  * - Streaming audio
  * - Voice Wake support
  */
-
-import { logger } from '../utils/logger';
 
 export interface Voice {
   id: string;
@@ -23,24 +21,215 @@ export interface TTSOptions {
   similarity_boost?: number;
 }
 
+export type TTSProvider = 'elevenlabs' | 'atlas';
+
+export interface TTSServiceOptions {
+  provider?: TTSProvider;
+  apiKey?: string;
+  atlasBaseUrl?: string;
+  atlasPollIntervalMs?: number;
+  atlasMaxPollAttempts?: number;
+}
+
 export interface TTSService {
+  provider: TTSProvider;
   synthesize(text: string, options?: TTSOptions): Promise<Buffer>;
   streamSynthesize(text: string, options?: TTSOptions): AsyncGenerator<Buffer>;
   listVoices(): Promise<Voice[]>;
   isAvailable(): boolean;
 }
 
-/** Create TTS service (requires ELEVENLABS_API_KEY) */
-export function createTTSService(): TTSService {
-  const apiKey = process.env.ELEVENLABS_API_KEY;
+interface AtlasPredictionData {
+  id?: string;
+  outputs?: string[] | null;
+  status?: string;
+  error?: string;
+}
+
+interface AtlasPredictionResponse {
+  code?: number;
+  message?: string;
+  data?: AtlasPredictionData;
+}
+
+const ATLAS_MODEL = 'elevenlabs/v3/text-to-speech';
+const DEFAULT_ATLAS_BASE_URL = 'https://api.atlascloud.ai/api/v1';
+
+function atlasHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function readAtlasResponse(response: Response, operation: string): Promise<AtlasPredictionResponse> {
+  if (!response.ok) {
+    throw new Error(`Atlas Cloud ${operation} failed: ${response.status}`);
+  }
+
+  const payload = await response.json() as AtlasPredictionResponse;
+  if (payload.code !== undefined && payload.code !== 200) {
+    throw new Error(`Atlas Cloud ${operation} failed: ${payload.message || payload.code}`);
+  }
+  return payload;
+}
+
+function getCompletedOutput(data: AtlasPredictionData | undefined): string | undefined {
+  if (data?.status !== 'completed') return undefined;
+  return data.outputs?.[0];
+}
+
+function validateHttpsUrl(value: string, label: string): URL {
+  const url = new URL(value);
+  if (url.protocol !== 'https:') {
+    throw new Error(`${label} must use HTTPS.`);
+  }
+  return url;
+}
+
+async function downloadAtlasOutput(output: string): Promise<Buffer> {
+  const response = await fetch(validateHttpsUrl(output, 'Atlas Cloud output URL'));
+  if (!response.ok) {
+    throw new Error(`Atlas Cloud audio download failed: ${response.status}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function synthesizeWithAtlas(
+  apiKey: string,
+  baseUrl: string,
+  text: string,
+  options: TTSOptions,
+  pollIntervalMs: number,
+  maxPollAttempts: number,
+): Promise<Buffer> {
+  if (text.length < 1 || text.length > 5000) {
+    throw new Error('Atlas Cloud TTS text must contain between 1 and 5,000 characters.');
+  }
+
+  const body: Record<string, string | number> = {
+    model: ATLAS_MODEL,
+    text,
+    stability: options.stability ?? 0.5,
+    apply_text_normalization: 'auto',
+  };
+  if (options.voice) body.voice = options.voice;
+
+  // Generation is submitted exactly once. Only the read-only status call is polled.
+  const submitResponse = await fetch(`${baseUrl}/model/generateAudio`, {
+    method: 'POST',
+    headers: atlasHeaders(apiKey),
+    body: JSON.stringify(body),
+  });
+  let prediction = await readAtlasResponse(submitResponse, 'generation');
+
+  for (let attempt = 0; attempt <= maxPollAttempts; attempt += 1) {
+    const output = getCompletedOutput(prediction.data);
+    if (output) return downloadAtlasOutput(output);
+
+    const status = prediction.data?.status;
+    if (status === 'completed') {
+      throw new Error('Atlas Cloud generation completed without an audio output.');
+    }
+    if (status === 'failed' || status === 'timeout') {
+      throw new Error(`Atlas Cloud generation ${status}: ${prediction.data?.error || 'unknown error'}`);
+    }
+    if (!prediction.data?.id) {
+      throw new Error('Atlas Cloud generation response did not include a request ID.');
+    }
+    if (attempt === maxPollAttempts) {
+      throw new Error('Atlas Cloud generation did not complete before the polling limit.');
+    }
+
+    if (pollIntervalMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    }
+    const pollResponse = await fetch(
+      `${baseUrl}/model/prediction/${encodeURIComponent(prediction.data.id)}`,
+      { headers: atlasHeaders(apiKey) },
+    );
+    prediction = await readAtlasResponse(pollResponse, 'status check');
+  }
+
+  throw new Error('Atlas Cloud generation did not complete.');
+}
+
+async function listAtlasVoices(apiKey: string, baseUrl: string): Promise<Voice[]> {
+  const modelsResponse = await fetch(`${baseUrl}/models`, { headers: atlasHeaders(apiKey) });
+  if (!modelsResponse.ok) return [];
+
+  const catalog = await modelsResponse.json() as {
+    data?: Array<{ model?: string; schema?: string }>;
+  };
+  const schemaValue = catalog.data?.find(item => item.model === ATLAS_MODEL)?.schema;
+  if (!schemaValue) return [];
+
+  const schemaUrl = validateHttpsUrl(schemaValue, 'Atlas Cloud model schema URL');
+  if (schemaUrl.hostname !== 'static.atlascloud.ai') {
+    throw new Error('Atlas Cloud model schema URL used an unexpected host.');
+  }
+
+  const schemaResponse = await fetch(schemaUrl);
+  if (!schemaResponse.ok) return [];
+  const schema = await schemaResponse.json() as {
+    components?: {
+      schemas?: {
+        Input?: {
+          properties?: {
+            voice?: {
+              'x-enum-options'?: Record<string, { name?: string; example?: string }>;
+            };
+          };
+        };
+      };
+    };
+  };
+  const voices = schema.components?.schemas?.Input?.properties?.voice?.['x-enum-options'];
+  if (!voices) return [];
+
+  return Object.entries(voices).map(([id, voice]) => ({
+    id,
+    name: voice.name || id,
+    preview_url: voice.example,
+  }));
+}
+
+/** Create a TTS service. ElevenLabs remains the default provider. */
+export function createTTSService(options: TTSServiceOptions = {}): TTSService {
+  const requestedProvider = options.provider || process.env.CLODDS_TTS_PROVIDER || 'elevenlabs';
+  if (requestedProvider !== 'elevenlabs' && requestedProvider !== 'atlas') {
+    throw new Error(`Unsupported TTS provider: ${requestedProvider}`);
+  }
+
+  const provider: TTSProvider = requestedProvider;
+  const apiKey = options.apiKey || (
+    provider === 'atlas' ? process.env.ATLASCLOUD_API_KEY : process.env.ELEVENLABS_API_KEY
+  );
+  const atlasBaseUrl = (options.atlasBaseUrl || DEFAULT_ATLAS_BASE_URL).replace(/\/+$/, '');
+  const atlasPollIntervalMs = Math.max(0, options.atlasPollIntervalMs ?? 1000);
+  const atlasMaxPollAttempts = Math.max(1, options.atlasMaxPollAttempts ?? 120);
 
   return {
-    async synthesize(text, options = {}) {
+    provider,
+
+    async synthesize(text, synthOptions = {}) {
       if (!apiKey) {
-        throw new Error('TTS not configured. Set ELEVENLABS_API_KEY.');
+        const variable = provider === 'atlas' ? 'ATLASCLOUD_API_KEY' : 'ELEVENLABS_API_KEY';
+        throw new Error(`TTS not configured. Set ${variable}.`);
       }
 
-      const voiceId = options.voice || 'EXAVITQu4vr4xnSDxMaL'; // Default: Bella
+      if (provider === 'atlas') {
+        return synthesizeWithAtlas(
+          apiKey,
+          atlasBaseUrl,
+          text,
+          synthOptions,
+          atlasPollIntervalMs,
+          atlasMaxPollAttempts,
+        );
+      }
+
+      const voiceId = synthOptions.voice || 'EXAVITQu4vr4xnSDxMaL'; // Default: Bella
       const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
         method: 'POST',
         headers: {
@@ -49,10 +238,10 @@ export function createTTSService(): TTSService {
         },
         body: JSON.stringify({
           text,
-          model_id: options.model || 'eleven_monolingual_v1',
+          model_id: synthOptions.model || 'eleven_monolingual_v1',
           voice_settings: {
-            stability: options.stability ?? 0.5,
-            similarity_boost: options.similarity_boost ?? 0.75,
+            stability: synthOptions.stability ?? 0.5,
+            similarity_boost: synthOptions.similarity_boost ?? 0.75,
           },
         }),
       });
@@ -61,18 +250,17 @@ export function createTTSService(): TTSService {
         throw new Error(`TTS failed: ${response.status}`);
       }
 
-      const arrayBuffer = await response.arrayBuffer();
-      return Buffer.from(arrayBuffer);
+      return Buffer.from(await response.arrayBuffer());
     },
 
-    async *streamSynthesize(text, options = {}) {
-      // For now, just return the full buffer
-      const buffer = await this.synthesize(text, options);
+    async *streamSynthesize(text, synthOptions = {}) {
+      const buffer = await this.synthesize(text, synthOptions);
       yield buffer;
     },
 
     async listVoices() {
       if (!apiKey) return [];
+      if (provider === 'atlas') return listAtlasVoices(apiKey, atlasBaseUrl);
 
       const response = await fetch('https://api.elevenlabs.io/v1/voices', {
         headers: { 'xi-api-key': apiKey },

--- a/tests/unit/tts.test.ts
+++ b/tests/unit/tts.test.ts
@@ -1,0 +1,169 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTTSService } from '../../src/tts';
+
+test('ElevenLabs remains the default TTS provider', async () => {
+  const originalFetch = globalThis.fetch;
+  let requestUrl = '';
+  let requestInit: RequestInit | undefined;
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    requestUrl = String(input);
+    requestInit = init;
+    return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const service = createTTSService({ apiKey: 'eleven-key' });
+    const audio = await service.synthesize('hello');
+
+    assert.equal(service.provider, 'elevenlabs');
+    assert.equal(requestUrl, 'https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL');
+    assert.equal(requestInit?.method, 'POST');
+    assert.equal((requestInit?.headers as Record<string, string>)['xi-api-key'], 'eleven-key');
+    assert.deepEqual([...audio], [1, 2, 3]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('Atlas Cloud submits once and polls the prediction endpoint', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init });
+
+    if (url.endsWith('/model/generateAudio')) {
+      return Response.json({ code: 200, data: { id: 'request/1', status: 'created' } });
+    }
+    if (url.endsWith('/model/prediction/request%2F1')) {
+      return Response.json({
+        code: 200,
+        data: { id: 'request/1', status: 'completed', outputs: ['https://cdn.example/audio.mp3'] },
+      });
+    }
+    if (url === 'https://cdn.example/audio.mp3') {
+      return new Response(new Uint8Array([4, 5, 6]), { status: 200 });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const service = createTTSService({
+      provider: 'atlas',
+      apiKey: 'atlas-key',
+      atlasBaseUrl: 'https://api.example/api/v1/',
+      atlasPollIntervalMs: 0,
+      atlasMaxPollAttempts: 2,
+    });
+    const audio = await service.synthesize('market alert', {
+      voice: 'voice-1',
+      stability: 0.7,
+      similarity_boost: 0.9,
+    });
+
+    assert.equal(service.provider, 'atlas');
+    assert.equal(calls.filter(call => call.init?.method === 'POST').length, 1);
+    assert.equal(calls[0]?.url, 'https://api.example/api/v1/model/generateAudio');
+    assert.deepEqual(JSON.parse(String(calls[0]?.init?.body)), {
+      model: 'elevenlabs/v3/text-to-speech',
+      text: 'market alert',
+      stability: 0.7,
+      apply_text_normalization: 'auto',
+      voice: 'voice-1',
+    });
+    assert.equal(calls[1]?.url, 'https://api.example/api/v1/model/prediction/request%2F1');
+    assert.deepEqual([...audio], [4, 5, 6]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('Atlas Cloud reads voice choices from the live model schema', async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.endsWith('/models')) {
+      return Response.json({
+        data: [{
+          model: 'elevenlabs/v3/text-to-speech',
+          schema: 'https://static.atlascloud.ai/model/schema/tts.json',
+        }],
+      });
+    }
+    if (url === 'https://static.atlascloud.ai/model/schema/tts.json') {
+      return Response.json({
+        components: {
+          schemas: {
+            Input: {
+              properties: {
+                voice: {
+                  'x-enum-options': {
+                    'voice-1': { name: 'Test Voice', example: 'https://static.atlascloud.ai/voice.mp3' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const service = createTTSService({
+      provider: 'atlas',
+      apiKey: 'atlas-key',
+      atlasBaseUrl: 'https://api.example/api/v1',
+    });
+    assert.deepEqual(await service.listVoices(), [{
+      id: 'voice-1',
+      name: 'Test Voice',
+      preview_url: 'https://static.atlascloud.ai/voice.mp3',
+    }]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('Atlas Cloud surfaces terminal generation failures without resubmitting', async () => {
+  const originalFetch = globalThis.fetch;
+  let postCount = 0;
+
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    if (init?.method === 'POST') postCount += 1;
+    return Response.json({
+      code: 200,
+      data: { id: 'request-1', status: 'failed', error: 'invalid input' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const service = createTTSService({ provider: 'atlas', apiKey: 'atlas-key' });
+    await assert.rejects(() => service.synthesize('hello'), /invalid input/);
+    assert.equal(postCount, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('Atlas Cloud rejects invalid text before submitting generation', async () => {
+  const originalFetch = globalThis.fetch;
+  let requestCount = 0;
+  globalThis.fetch = (async () => {
+    requestCount += 1;
+    return Response.json({ code: 200 });
+  }) as typeof fetch;
+
+  try {
+    const service = createTTSService({ provider: 'atlas', apiKey: 'atlas-key' });
+    await assert.rejects(() => service.synthesize(''), /between 1 and 5,000 characters/);
+    assert.equal(requestCount, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an opt-in TTS provider while keeping ElevenLabs as the default
- submit Atlas generation exactly once, then use bounded read-only prediction polling
- load Atlas voice choices from the live model schema and expose the provider in env/gateway configuration
- make TTS command status, errors, defaults, and docs provider-aware

## Safety and compatibility

- preserves the existing ElevenLabs request path and defaults
- validates Atlas text length before submission
- constructs prediction URLs locally instead of following response-provided URLs
- accepts only HTTPS output/schema URLs and restricts model schemas to static.atlascloud.ai

## Testing

- PASS: node --test --import tsx --import ./tests/helpers/test-setup.ts tests/unit/tts.test.ts (5/5)
- PASS: strict focused tsc for src/tts/index.ts and src/skills/bundled/tts/index.ts
- NOTE: npm run typecheck and npm run build remain blocked by pre-existing missing dependencies (including viem, tweetnacl, decimal.js, and @noble/curves) plus an unrelated Puppeteer type error. The same failures were reproduced from unmodified commit e71a5f6.