### PR TITLE
feat: Polymarket V2 exchange support (order signing, auto version detection, approvals)

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -20,7 +20,11 @@ import {
 import {
   buildSignedOrder,
   buildSignedOrders,
+  buildSignedOrderV2,
+  buildSignedOrdersV2,
+  getCurrentPolymarketOrderVersion,
   type PostOrderBody,
+  type PostOrderBodyV2,
   type SignerConfig,
 } from '../utils/polymarket-order-signer';
 import {
@@ -287,12 +291,19 @@ const POLY_CLOB_URL = process.env.POLY_CLOB_URL || 'https://clob.polymarket.com'
 // Mainnet (default):
 //   CTF: 0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E
 //   NEG_RISK: 0xC5d563A36AE78145C45a50134d48A1215220f80a
+//   CTF_V2: 0xE111180000d2663C0091e4f400237545B87B996B
+//   NEG_RISK_V2: 0xe2222d279d744050d28e00520010520000310F59
 // Amoy Testnet:
 //   POLY_CLOB_URL=https://clob.polymarket.com (same)
 //   POLY_CTF_EXCHANGE=0xdFE02Eb6733538f8Ea35D585af8DE5958AD99E40
 //   POLY_NEG_RISK_CTF_EXCHANGE=0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296
 const POLY_CTF_EXCHANGE = process.env.POLY_CTF_EXCHANGE || '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
 const POLY_NEG_RISK_CTF_EXCHANGE = process.env.POLY_NEG_RISK_CTF_EXCHANGE || '0xC5d563A36AE78145C45a50134d48A1215220f80a';
+// V1 and V2 exchanges are both live on-chain simultaneously (verified) — GET /version on
+// the live CLOB currently returns 2, meaning V2 is the exchange-wide default order
+// format right now. See polymarket-order-signer.ts's file header for the full story.
+const POLY_CTF_EXCHANGE_V2 = process.env.POLY_CTF_EXCHANGE_V2 || '0xE111180000d2663C0091e4f400237545B87B996B';
+const POLY_NEG_RISK_CTF_EXCHANGE_V2 = process.env.POLY_NEG_RISK_CTF_EXCHANGE_V2 || '0xe2222d279d744050d28e00520010520000310F59';
 
 /**
  * Retry helper with exponential backoff for Polymarket REST API calls
@@ -1178,15 +1189,16 @@ async function placeSignedPolymarketOrder(
     signatureType: auth.signatureType,
   };
 
-  const postOrder = buildSignedOrder({
-    tokenId,
-    price,
-    size,
-    side: side === 'buy' ? 'buy' : 'sell',
-    negRisk,
-    feeRateBps,
-    nonce: getNextNonce(),
-  }, signerCfg);
+  // The live exchange currently defaults to V2 (GET /version), but isn't required to
+  // stay that way — resolve per-order (cached 5 min) rather than hardcoding a version.
+  const version = await getCurrentPolymarketOrderVersion(POLY_CLOB_URL);
+  const postOrder: PostOrderBody | PostOrderBodyV2 = version === 1
+    ? buildSignedOrder({
+        tokenId, price, size, side: side === 'buy' ? 'buy' : 'sell', negRisk, feeRateBps, nonce: getNextNonce(),
+      }, signerCfg)
+    : buildSignedOrderV2({
+        tokenId, price, size, side: side === 'buy' ? 'buy' : 'sell', negRisk,
+      }, signerCfg); // feeRateBps has no V2 equivalent — fees are exchange-computed, not client-specified
 
   // Set owner to API key (required by Polymarket CLOB)
   postOrder.owner = auth.apiKey;
@@ -1213,7 +1225,7 @@ async function placeSignedPolymarketOrder(
     }
 
     const orderId = data.orderID || data.order_id;
-    logger.info({ orderId, tokenId, side, price, size, feeRateBps }, 'Polymarket signed order placed');
+    logger.info({ orderId, tokenId, side, price, size, feeRateBps, version }, 'Polymarket signed order placed');
     return { success: true, orderId, status: 'open', transactionHash: data.transactionsHashes?.[0] };
   } catch (error) {
     logger.error({ error }, 'Error placing Polymarket signed order after retries');
@@ -1321,16 +1333,17 @@ async function placePolymarketOrdersBatch(
     signatureType: auth.signatureType,
   };
 
-  const postOrders: PostOrderBody[] = buildSignedOrders(
-    orders.map(o => ({
-      tokenId: o.tokenId,
-      price: o.price,
-      size: o.size,
-      side: o.side === 'buy' ? 'buy' as const : 'sell' as const,
-      negRisk: o.negRisk,
-    })),
-    signerCfg,
-  );
+  const version = await getCurrentPolymarketOrderVersion(POLY_CLOB_URL);
+  const orderParamsList = orders.map(o => ({
+    tokenId: o.tokenId,
+    price: o.price,
+    size: o.size,
+    side: o.side === 'buy' ? 'buy' as const : 'sell' as const,
+    negRisk: o.negRisk,
+  }));
+  const postOrders: Array<PostOrderBody | PostOrderBodyV2> = version === 1
+    ? buildSignedOrders(orderParamsList, signerCfg)
+    : buildSignedOrdersV2(orderParamsList, signerCfg);
 
   // Set owner to API key on all orders (required by Polymarket CLOB)
   for (const po of postOrders) {
@@ -3614,9 +3627,19 @@ export function createExecutionService(config: ExecutionConfig): ExecutionServic
           error: 'Polymarket private key not configured',
         };
       }
-      // Approve for both CTF exchanges
-      const spender = POLY_CTF_EXCHANGE;
-      return approvePolymarketUSDC(config.polymarket.privateKey, spender, amount);
+      // Approve every exchange a signed order might target (V1 + V2, standard + negRisk)
+      // so trading isn't blocked by an allowance gap on whichever version/market the
+      // order actually lands on.
+      const spenders = [POLY_CTF_EXCHANGE, POLY_NEG_RISK_CTF_EXCHANGE, POLY_CTF_EXCHANGE_V2, POLY_NEG_RISK_CTF_EXCHANGE_V2];
+      const results = await Promise.all(
+        spenders.map(spender => approvePolymarketUSDC(config.polymarket!.privateKey!, spender, amount))
+      );
+      const failed = results.find(r => !r.success);
+      return {
+        success: !failed,
+        txHash: results.map(r => r.txHash).filter(Boolean).join(','),
+        error: failed?.error,
+      };
     },
 
     async getUSDCAllowance() {
@@ -3624,7 +3647,11 @@ export function createExecutionService(config: ExecutionConfig): ExecutionServic
         return 0;
       }
       const owner = config.polymarket.funderAddress || config.polymarket.address;
-      return getPolymarketUSDCAllowance(owner, POLY_CTF_EXCHANGE);
+      // Report the binding constraint — the lowest allowance across every exchange a
+      // signed order might target.
+      const spenders = [POLY_CTF_EXCHANGE, POLY_NEG_RISK_CTF_EXCHANGE, POLY_CTF_EXCHANGE_V2, POLY_NEG_RISK_CTF_EXCHANGE_V2];
+      const allowances = await Promise.all(spenders.map(spender => getPolymarketUSDCAllowance(owner, spender)));
+      return Math.min(...allowances);
     },
 
     // =========================================================================
@@ -3691,6 +3718,8 @@ export type { PolymarketApiKeyAuth, KalshiApiKeyAuth, OpinionApiAuth };
 export const POLYMARKET_EXCHANGES = {
   CTF: POLY_CTF_EXCHANGE,
   NEG_RISK_CTF: POLY_NEG_RISK_CTF_EXCHANGE,
+  CTF_V2: POLY_CTF_EXCHANGE_V2,
+  NEG_RISK_CTF_V2: POLY_NEG_RISK_CTF_EXCHANGE_V2,
 };
 
 // Re-export sub-modules

--- a/src/utils/polymarket-order-signer.ts
+++ b/src/utils/polymarket-order-signer.ts
@@ -1,13 +1,23 @@
 /**
  * Polymarket CLOB Order Signing (EIP-712)
  *
- * Builds and signs orders for the Polymarket CTF Exchange contract.
+ * Builds and signs orders for the Polymarket CTF Exchange contract. Both V1 and V2
+ * exchanges are live simultaneously (verified on-chain) — GET /version on the live
+ * CLOB currently returns 2, meaning V2 is the exchange-wide default order format
+ * right now, but V1 is not dead (repo archival on GitHub reflects where new
+ * development happens, not that the deployed V1 contract stopped working).
  * Uses the same @noble/curves + @noble/hashes primitives as x402/evm.ts.
  *
  * Reference:
- *   - Contract: https://github.com/Polymarket/ctf-exchange
+ *   - V1 contract (archived repo, still live on-chain): https://github.com/Polymarket/ctf-exchange
+ *   - V2 contract: https://github.com/Polymarket/ctf-exchange-v2
  *   - Order utils: https://github.com/Polymarket/clob-order-utils
- *   - EIP-712 domain: { name: "Polymarket CTF Exchange", version: "1", chainId: 137, verifyingContract: <exchange> }
+ *   - V1 EIP-712 domain: { name: "Polymarket CTF Exchange", version: "1", chainId: 137, verifyingContract: <exchange> }
+ *   - V2 EIP-712 domain: { name: "Polymarket CTF Exchange", version: "2", chainId: 137, verifyingContract: <exchangeV2> }
+ *   - V2 has no taker/expiration(struct)/nonce/feeRateBps fields — replaced by
+ *     timestamp (unix ms) + metadata (bytes32) + builder (bytes32), all verified
+ *     against ctf-exchange-v2's Structs.sol/Hashing.sol and clob-client-v2's
+ *     exchangeOrderBuilderV2.ts (both agree byte-for-byte on the type string).
  */
 
 import { keccak_256 } from '@noble/hashes/sha3';
@@ -20,28 +30,45 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 
 const PROTOCOL_NAME = 'Polymarket CTF Exchange';
 const PROTOCOL_VERSION = '1';
+const PROTOCOL_VERSION_V2 = '2';
 const CHAIN_ID = 137; // Polygon
 
-/** CTF Exchange (standard binary markets) */
+/** CTF Exchange V1 (standard binary markets) */
 export const CTF_EXCHANGE = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
-/** Neg Risk CTF Exchange (multi-outcome / crypto markets) */
+/** Neg Risk CTF Exchange V1 (multi-outcome / crypto markets) */
 export const NEG_RISK_CTF_EXCHANGE = '0xC5d563A36AE78145C45a50134d48A1215220f80a';
+/** CTF Exchange V2 — verified live on Polygon (real bytecode), matches clob-client-v2's config.ts */
+export const CTF_EXCHANGE_V2 = '0xE111180000d2663C0091e4f400237545B87B996B';
+/** Neg Risk CTF Exchange V2 — verified live on Polygon */
+export const NEG_RISK_CTF_EXCHANGE_V2 = '0xe2222d279d744050d28e00520010520000310F59';
 
-/** Operator/taker address (Polymarket's operator) */
+/** Operator/taker address (Polymarket's operator) — V1 only, V2 has no taker field */
 const OPERATOR_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+/** 32 zero bytes — V2's default metadata/builder value when the caller doesn't set one */
+const BYTES32_ZERO = '0x' + '0'.repeat(64);
 
 /** USDC has 6 decimals on Polygon */
 const USDC_DECIMALS = 6;
 
-// EIP-712 type string for Order struct
+// EIP-712 type string for the V1 Order struct
 const ORDER_TYPE_STRING =
   'Order(uint256 salt,address maker,address signer,address taker,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint256 expiration,uint256 nonce,uint256 feeRateBps,uint8 side,uint8 signatureType)';
 
-// Signature types
+// EIP-712 type string for the V2 Order struct — no taker/nonce/feeRateBps, adds
+// timestamp/metadata/builder. Verified identical in both ctf-exchange-v2's
+// Structs.sol comment and clob-client-v2's exchangeOrderBuilderV2.ts.
+const ORDER_TYPE_STRING_V2 =
+  'Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)';
+
+// Signature types (V1 supports EOA/POLY_PROXY/POLY_GNOSIS_SAFE; V2 adds POLY_1271 for
+// smart-contract wallets, which needs a different nested-signature scheme entirely and
+// is intentionally not implemented here — buildSignedOrderV2 throws if it's requested)
 export enum SignatureType {
   EOA = 0,
   POLY_PROXY = 1,
   POLY_GNOSIS_SAFE = 2,
+  POLY_1271 = 3,
 }
 
 // Side enum matching contract
@@ -110,6 +137,52 @@ export interface OrderParams {
   nonce?: string;
   expiration?: number;
   negRisk?: boolean;
+  /** V2 only — bytes32 hex string, defaults to 32 zero bytes if omitted */
+  metadata?: string;
+  /** V2 only — bytes32 hex string, defaults to 32 zero bytes if omitted */
+  builderCode?: string;
+}
+
+export interface PolymarketOrderV2 {
+  salt: string;
+  maker: string;
+  signer: string;
+  tokenId: string;
+  makerAmount: string;
+  takerAmount: string;
+  side: string;
+  signatureType: number;
+  timestamp: string;
+  metadata: string;
+  builder: string;
+}
+
+/**
+ * JSON body for POST /order under the V2 order format — verified against
+ * clob-client-v2's ordersV2.ts orderToJsonV2(). No `nonce`/`feeRateBps` (V1-only);
+ * adds `timestamp`/`metadata`/`builder`. `expiration` here is API/off-chain
+ * bookkeeping for the CLOB matching engine, not part of the signed EIP-712 struct.
+ */
+export interface PostOrderBodyV2 {
+  order: {
+    salt: number;
+    maker: string;
+    signer: string;
+    tokenId: string;
+    makerAmount: string;
+    takerAmount: string;
+    side: 'BUY' | 'SELL';
+    signatureType: number;
+    timestamp: string;
+    expiration: string;
+    metadata: string;
+    builder: string;
+    signature: string;
+  };
+  owner: string;
+  orderType: 'GTC' | 'GTD' | 'FOK';
+  deferExec: boolean;
+  postOnly?: boolean;
 }
 
 // =============================================================================
@@ -307,6 +380,71 @@ function createTypedDataHash(contractAddress: string, order: PolymarketOrder): s
   return '0x' + keccak256(encoded);
 }
 
+// V2 domain — same 4-field EIP712Domain shape as V1, just a different version string
+// ("2"), so it gets its own hash rather than parametrizing hashDomain (keeps the
+// already-verified V1 path untouched).
+function hashDomainV2(contractAddress: string): string {
+  const typeHash = Buffer.from(keccak256(
+    Buffer.from('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+  ), 'hex');
+
+  const nameHash = Buffer.from(keccak256(Buffer.from(PROTOCOL_NAME)), 'hex');
+  const versionHash = Buffer.from(keccak256(Buffer.from(PROTOCOL_VERSION_V2)), 'hex');
+  const chainIdHex = CHAIN_ID.toString(16).padStart(64, '0');
+  const contractHex = contractAddress.slice(2).toLowerCase().padStart(64, '0');
+
+  const encoded = Buffer.concat([
+    typeHash,
+    nameHash,
+    versionHash,
+    Buffer.from(chainIdHex, 'hex'),
+    Buffer.from(contractHex, 'hex'),
+  ]);
+
+  return '0x' + keccak256(encoded);
+}
+
+function encodeBytes32(value: string): string {
+  const hex = value.startsWith('0x') ? value.slice(2) : value;
+  return hex.toLowerCase().padStart(64, '0');
+}
+
+// Field order here must exactly match ORDER_TYPE_STRING_V2's declared order — EIP-712
+// struct hashing is positional (by type-string field order), not by object key order.
+function hashOrderV2(order: PolymarketOrderV2): string {
+  const typeHash = Buffer.from(keccak256(Buffer.from(ORDER_TYPE_STRING_V2)), 'hex');
+
+  const encoded = Buffer.concat([
+    typeHash,
+    Buffer.from(encodeUint256(order.salt), 'hex'),
+    Buffer.from(encodeAddress(order.maker), 'hex'),
+    Buffer.from(encodeAddress(order.signer), 'hex'),
+    Buffer.from(encodeUint256(order.tokenId), 'hex'),
+    Buffer.from(encodeUint256(order.makerAmount), 'hex'),
+    Buffer.from(encodeUint256(order.takerAmount), 'hex'),
+    Buffer.from(encodeUint256(order.side), 'hex'),
+    Buffer.from(encodeUint256(order.signatureType), 'hex'),
+    Buffer.from(encodeUint256(order.timestamp), 'hex'),
+    Buffer.from(encodeBytes32(order.metadata), 'hex'),
+    Buffer.from(encodeBytes32(order.builder), 'hex'),
+  ]);
+
+  return '0x' + keccak256(encoded);
+}
+
+function createTypedDataHashV2(contractAddress: string, order: PolymarketOrderV2): string {
+  const domainSeparator = hashDomainV2(contractAddress);
+  const structHash = hashOrderV2(order);
+
+  const encoded = Buffer.concat([
+    Buffer.from([0x19, 0x01]),
+    Buffer.from(domainSeparator.slice(2), 'hex'),
+    Buffer.from(structHash.slice(2), 'hex'),
+  ]);
+
+  return '0x' + keccak256(encoded);
+}
+
 // =============================================================================
 // SIGNING
 // =============================================================================
@@ -446,4 +584,122 @@ export function buildSignedOrders(
   signer: SignerConfig,
 ): PostOrderBody[] {
   return paramsList.map((p) => buildSignedOrder(p, signer));
+}
+
+/**
+ * Build and sign a Polymarket CLOB order in the V2 format (see file header for what
+ * changed vs V1). Use getCurrentPolymarketOrderVersion() to decide whether to call
+ * this or buildSignedOrder() — V2 is the live exchange-wide default as of this
+ * writing, but callers that already know their target version can call either
+ * directly.
+ * @throws {OrderValidationError} if order parameters are invalid
+ */
+export function buildSignedOrderV2(
+  params: OrderParams,
+  signer: SignerConfig,
+): PostOrderBodyV2 {
+  validateOrderParams(params);
+
+  const signatureType = signer.signatureType ?? (signer.funderAddress ? SignatureType.POLY_GNOSIS_SAFE : SignatureType.EOA);
+  if (signatureType === SignatureType.POLY_1271) {
+    throw new Error(
+      'POLY_1271 (smart-contract wallet) signing is not implemented — it requires a nested ' +
+      'TypedDataSign wrapper around the order, not a plain EIP-712 signature. Use EOA, ' +
+      'POLY_PROXY, or POLY_GNOSIS_SAFE instead.'
+    );
+  }
+
+  const signerAddress = deriveAddress(signer.privateKey);
+  const maker = signer.funderAddress || signerAddress;
+  const exchange = params.negRisk ? NEG_RISK_CTF_EXCHANGE_V2 : CTF_EXCHANGE_V2;
+
+  const { makerAmount, takerAmount } = getOrderAmounts(params.price, params.size, params.side);
+  const salt = generateSalt();
+  const timestamp = Date.now().toString();
+  const sideNum = params.side === 'buy' ? OrderSide.BUY : OrderSide.SELL;
+  const metadata = params.metadata ? normalizeBytes32(params.metadata) : BYTES32_ZERO;
+  const builder = params.builderCode ? normalizeBytes32(params.builderCode) : BYTES32_ZERO;
+
+  const order: PolymarketOrderV2 = {
+    salt,
+    maker,
+    signer: signerAddress,
+    tokenId: params.tokenId,
+    makerAmount,
+    takerAmount,
+    side: sideNum.toString(),
+    signatureType,
+    timestamp,
+    metadata,
+    builder,
+  };
+
+  const hash = createTypedDataHashV2(exchange, order);
+  const signature = signHash(hash, signer.privateKey);
+
+  return {
+    order: {
+      salt: parseInt(salt, 10),
+      maker,
+      signer: signerAddress,
+      tokenId: params.tokenId,
+      makerAmount,
+      takerAmount,
+      side: params.side === 'buy' ? 'BUY' : 'SELL',
+      signatureType,
+      timestamp,
+      expiration: (params.expiration || 0).toString(),
+      metadata,
+      builder,
+      signature,
+    },
+    owner: '', // Caller MUST set this to the API key
+    orderType: 'GTC',
+    deferExec: false,
+  };
+}
+
+/**
+ * Build multiple V2 signed orders for batch placement.
+ */
+export function buildSignedOrdersV2(
+  paramsList: OrderParams[],
+  signer: SignerConfig,
+): PostOrderBodyV2[] {
+  return paramsList.map((p) => buildSignedOrderV2(p, signer));
+}
+
+function normalizeBytes32(value: string): string {
+  return value.startsWith('0x') ? value : `0x${value}`;
+}
+
+// =============================================================================
+// EXCHANGE VERSION RESOLUTION
+// =============================================================================
+
+let cachedVersion: { version: 1 | 2; fetchedAt: number } | null = null;
+const VERSION_CACHE_MS = 5 * 60 * 1000; // 5 min — exchange-wide version flips are rare, no need to check every order
+
+/**
+ * Ask the live CLOB which order version it currently expects (GET /version).
+ * Falls back to 2 on any failure — matches clob-client-v2's own fallback
+ * (`response?.version ?? 2`); confirmed live that the endpoint currently returns 2.
+ */
+export async function getCurrentPolymarketOrderVersion(
+  clobBaseUrl: string = 'https://clob.polymarket.com',
+): Promise<1 | 2> {
+  if (cachedVersion && Date.now() - cachedVersion.fetchedAt < VERSION_CACHE_MS) {
+    return cachedVersion.version;
+  }
+  try {
+    const res = await fetch(`${clobBaseUrl}/version`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as { version?: number };
+    const version: 1 | 2 = data.version === 1 ? 1 : 2;
+    cachedVersion = { version, fetchedAt: Date.now() };
+    return version;
+  } catch {
+    cachedVersion = { version: 2, fetchedAt: Date.now() };
+    return 2;
+  }
 }

--- a/src/utils/polymarket-setup.ts
+++ b/src/utils/polymarket-setup.ts
@@ -24,12 +24,16 @@ const CLOB_URL = 'https://clob.polymarket.com';
 export const USDC_ADDRESS = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174';
 /** Conditional Tokens Framework (ERC-1155) */
 export const CTF_ADDRESS = '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045';
-/** CTF Exchange (standard binary markets) */
+/** CTF Exchange V1 (standard binary markets) */
 export const CTF_EXCHANGE = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
-/** NegRisk CTF Exchange (multi-outcome / crypto markets) */
+/** NegRisk CTF Exchange V1 (multi-outcome / crypto markets) */
 export const NEG_RISK_EXCHANGE = '0xC5d563A36AE78145C45a50134d48A1215220f80a';
 /** NegRisk Adapter */
 export const NEG_RISK_ADAPTER = '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296';
+/** CTF Exchange V2 — verified live on Polygon; see polymarket-order-signer.ts's file header */
+export const CTF_EXCHANGE_V2 = '0xE111180000d2663C0091e4f400237545B87B996B';
+/** NegRisk CTF Exchange V2 — verified live on Polygon */
+export const NEG_RISK_EXCHANGE_V2 = '0xe2222d279d744050d28e00520010520000310F59';
 
 // =============================================================================
 // API KEY DERIVATION (L1 Auth → L2 Credentials)
@@ -223,7 +227,10 @@ export interface ApprovalTx {
 /**
  * Generate the list of approval transactions needed for trading.
  *
- * Standard markets need 3 approvals, negRisk markets need 4 more (7 total).
+ * Standard V1 markets need 3 approvals, V1 negRisk adds 4 more. V1 and V2 exchanges
+ * are both live simultaneously (see polymarket-order-signer.ts's file header), so this
+ * also approves the V2 exchanges (2 more standard, 2 more negRisk) — up to 11 total —
+ * so trading isn't blocked by an allowance gap on whichever version a market lands on.
  * These must be sent from the funder address (proxy wallet for types 1/2, EOA for type 0).
  *
  * Returns raw transaction data — caller handles signing and sending via RPC.
@@ -239,12 +246,23 @@ export function getRequiredApprovals(options?: { includeNegRisk?: boolean }): Ap
     {
       to: USDC_ADDRESS,
       data: `0x${ERC20_APPROVE_SELECTOR}${encodeAddress(CTF_EXCHANGE)}${MAX_UINT256}`,
-      description: 'Approve USDC → CTF Exchange',
+      description: 'Approve USDC → CTF Exchange (V1)',
     },
     {
       to: CTF_ADDRESS,
       data: `0x${ERC1155_SET_APPROVAL_SELECTOR}${encodeAddress(CTF_EXCHANGE)}${'0'.repeat(63)}1`,
-      description: 'Approve CTF tokens → CTF Exchange (setApprovalForAll)',
+      description: 'Approve CTF tokens → CTF Exchange (V1, setApprovalForAll)',
+    },
+    // Standard V2 approvals (2)
+    {
+      to: USDC_ADDRESS,
+      data: `0x${ERC20_APPROVE_SELECTOR}${encodeAddress(CTF_EXCHANGE_V2)}${MAX_UINT256}`,
+      description: 'Approve USDC → CTF Exchange (V2)',
+    },
+    {
+      to: CTF_ADDRESS,
+      data: `0x${ERC1155_SET_APPROVAL_SELECTOR}${encodeAddress(CTF_EXCHANGE_V2)}${'0'.repeat(63)}1`,
+      description: 'Approve CTF tokens → CTF Exchange (V2, setApprovalForAll)',
     },
   ];
 
@@ -258,17 +276,27 @@ export function getRequiredApprovals(options?: { includeNegRisk?: boolean }): Ap
       {
         to: USDC_ADDRESS,
         data: `0x${ERC20_APPROVE_SELECTOR}${encodeAddress(NEG_RISK_EXCHANGE)}${MAX_UINT256}`,
-        description: 'Approve USDC → NegRisk Exchange',
+        description: 'Approve USDC → NegRisk Exchange (V1)',
       },
       {
         to: CTF_ADDRESS,
         data: `0x${ERC1155_SET_APPROVAL_SELECTOR}${encodeAddress(NEG_RISK_EXCHANGE)}${'0'.repeat(63)}1`,
-        description: 'Approve CTF tokens → NegRisk Exchange (setApprovalForAll)',
+        description: 'Approve CTF tokens → NegRisk Exchange (V1, setApprovalForAll)',
       },
       {
         to: CTF_ADDRESS,
         data: `0x${ERC1155_SET_APPROVAL_SELECTOR}${encodeAddress(NEG_RISK_ADAPTER)}${'0'.repeat(63)}1`,
         description: 'Approve CTF tokens → NegRisk Adapter (setApprovalForAll)',
+      },
+      {
+        to: USDC_ADDRESS,
+        data: `0x${ERC20_APPROVE_SELECTOR}${encodeAddress(NEG_RISK_EXCHANGE_V2)}${MAX_UINT256}`,
+        description: 'Approve USDC → NegRisk Exchange (V2)',
+      },
+      {
+        to: CTF_ADDRESS,
+        data: `0x${ERC1155_SET_APPROVAL_SELECTOR}${encodeAddress(NEG_RISK_EXCHANGE_V2)}${'0'.repeat(63)}1`,
+        description: 'Approve CTF tokens → NegRisk Exchange (V2, setApprovalForAll)',
       },
     );
   }
@@ -355,24 +383,37 @@ export async function checkAllApprovals(
   results.push({ description: 'USDC → CTF contract', approved: usdcToCtf >= minAllowance });
 
   const usdcToExchange = await checkErc20Allowance(rpcUrl, USDC_ADDRESS, walletAddress, CTF_EXCHANGE);
-  results.push({ description: 'USDC → CTF Exchange', approved: usdcToExchange >= minAllowance });
+  results.push({ description: 'USDC → CTF Exchange (V1)', approved: usdcToExchange >= minAllowance });
 
   // Standard ERC-1155 approval
   const ctfToExchange = await checkErc1155Approval(rpcUrl, CTF_ADDRESS, walletAddress, CTF_EXCHANGE);
-  results.push({ description: 'CTF → CTF Exchange', approved: ctfToExchange });
+  results.push({ description: 'CTF → CTF Exchange (V1)', approved: ctfToExchange });
+
+  // Standard V2 approvals
+  const usdcToExchangeV2 = await checkErc20Allowance(rpcUrl, USDC_ADDRESS, walletAddress, CTF_EXCHANGE_V2);
+  results.push({ description: 'USDC → CTF Exchange (V2)', approved: usdcToExchangeV2 >= minAllowance });
+
+  const ctfToExchangeV2 = await checkErc1155Approval(rpcUrl, CTF_ADDRESS, walletAddress, CTF_EXCHANGE_V2);
+  results.push({ description: 'CTF → CTF Exchange (V2)', approved: ctfToExchangeV2 });
 
   if (options?.includeNegRisk) {
     const usdcToAdapter = await checkErc20Allowance(rpcUrl, USDC_ADDRESS, walletAddress, NEG_RISK_ADAPTER);
     results.push({ description: 'USDC → NegRisk Adapter', approved: usdcToAdapter >= minAllowance });
 
     const usdcToNegExchange = await checkErc20Allowance(rpcUrl, USDC_ADDRESS, walletAddress, NEG_RISK_EXCHANGE);
-    results.push({ description: 'USDC → NegRisk Exchange', approved: usdcToNegExchange >= minAllowance });
+    results.push({ description: 'USDC → NegRisk Exchange (V1)', approved: usdcToNegExchange >= minAllowance });
 
     const ctfToNegExchange = await checkErc1155Approval(rpcUrl, CTF_ADDRESS, walletAddress, NEG_RISK_EXCHANGE);
-    results.push({ description: 'CTF → NegRisk Exchange', approved: ctfToNegExchange });
+    results.push({ description: 'CTF → NegRisk Exchange (V1)', approved: ctfToNegExchange });
 
     const ctfToAdapter = await checkErc1155Approval(rpcUrl, CTF_ADDRESS, walletAddress, NEG_RISK_ADAPTER);
     results.push({ description: 'CTF → NegRisk Adapter', approved: ctfToAdapter });
+
+    const usdcToNegExchangeV2 = await checkErc20Allowance(rpcUrl, USDC_ADDRESS, walletAddress, NEG_RISK_EXCHANGE_V2);
+    results.push({ description: 'USDC → NegRisk Exchange (V2)', approved: usdcToNegExchangeV2 >= minAllowance });
+
+    const ctfToNegExchangeV2 = await checkErc1155Approval(rpcUrl, CTF_ADDRESS, walletAddress, NEG_RISK_EXCHANGE_V2);
+    results.push({ description: 'CTF → NegRisk Exchange (V2)', approved: ctfToNegExchangeV2 });
   }
 
   return results;

--- a/tests/unit/polymarket-order-signer-v2.test.ts
+++ b/tests/unit/polymarket-order-signer-v2.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Wallet } from 'ethers';
+import {
+  buildSignedOrderV2,
+  SignatureType,
+  CTF_EXCHANGE_V2,
+  NEG_RISK_CTF_EXCHANGE_V2,
+} from '../../src/utils/polymarket-order-signer';
+
+// Well-known, funds-free Hardhat/Anvil default test account #0 — never used on any
+// real chain with real value. Same key used in fast-broadcast-byte-parity.test.ts.
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+/**
+ * Independent reference: computes the same V2 order signature via ethers' own
+ * EIP-712 implementation (Wallet.signTypedData), built directly from Polymarket's
+ * documented V2 domain/struct rather than reusing any of polymarket-order-signer.ts's
+ * own hashing code — so a bug in that file's hand-rolled keccak/ABI-encoding can't
+ * accidentally cancel out between the code under test and its own reference.
+ */
+async function referenceSignV2(
+  exchange: string,
+  order: {
+    salt: string; maker: string; signer: string; tokenId: string;
+    makerAmount: string; takerAmount: string; side: number; signatureType: number;
+    timestamp: string; metadata: string; builder: string;
+  }
+): Promise<string> {
+  const wallet = new Wallet(TEST_PRIVATE_KEY);
+  const domain = { name: 'Polymarket CTF Exchange', version: '2', chainId: 137, verifyingContract: exchange };
+  const types = {
+    Order: [
+      { name: 'salt', type: 'uint256' },
+      { name: 'maker', type: 'address' },
+      { name: 'signer', type: 'address' },
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'makerAmount', type: 'uint256' },
+      { name: 'takerAmount', type: 'uint256' },
+      { name: 'side', type: 'uint8' },
+      { name: 'signatureType', type: 'uint8' },
+      { name: 'timestamp', type: 'uint256' },
+      { name: 'metadata', type: 'bytes32' },
+      { name: 'builder', type: 'bytes32' },
+    ],
+  };
+  return wallet.signTypedData(domain, types, order);
+}
+
+describe('Polymarket V2 order signer byte parity with ethers EIP-712', () => {
+  it('produces a byte-identical signature to an independent ethers reference (standard exchange, BUY)', async () => {
+    const result = buildSignedOrderV2(
+      { tokenId: '21742633143463906290569050155826241533067272736897614950488156847949938836455', price: 0.5, size: 100, side: 'buy' },
+      { privateKey: TEST_PRIVATE_KEY, signatureType: SignatureType.EOA }
+    );
+
+    const refSig = await referenceSignV2(CTF_EXCHANGE_V2, {
+      salt: result.order.salt.toString(),
+      maker: result.order.maker,
+      signer: result.order.signer,
+      tokenId: result.order.tokenId,
+      makerAmount: result.order.makerAmount,
+      takerAmount: result.order.takerAmount,
+      side: 0,
+      signatureType: result.order.signatureType,
+      timestamp: result.order.timestamp,
+      metadata: result.order.metadata,
+      builder: result.order.builder,
+    });
+
+    assert.equal(result.order.signature.toLowerCase(), refSig.toLowerCase());
+  });
+
+  it('produces a byte-identical signature to an independent ethers reference (negRisk exchange, SELL)', async () => {
+    const result = buildSignedOrderV2(
+      { tokenId: '98765432109876543210987654321098765432109876543210987654321098765432109876', price: 0.73, size: 50, side: 'sell', negRisk: true },
+      { privateKey: TEST_PRIVATE_KEY, signatureType: SignatureType.EOA }
+    );
+
+    const refSig = await referenceSignV2(NEG_RISK_CTF_EXCHANGE_V2, {
+      salt: result.order.salt.toString(),
+      maker: result.order.maker,
+      signer: result.order.signer,
+      tokenId: result.order.tokenId,
+      makerAmount: result.order.makerAmount,
+      takerAmount: result.order.takerAmount,
+      side: 1,
+      signatureType: result.order.signatureType,
+      timestamp: result.order.timestamp,
+      metadata: result.order.metadata,
+      builder: result.order.builder,
+    });
+
+    assert.equal(result.order.signature.toLowerCase(), refSig.toLowerCase());
+  });
+
+  it('defaults metadata/builder to 32 zero bytes and rejects POLY_1271', () => {
+    const result = buildSignedOrderV2(
+      { tokenId: '21742633143463906290569050155826241533067272736897614950488156847949938836455', price: 0.5, size: 100, side: 'buy' },
+      { privateKey: TEST_PRIVATE_KEY }
+    );
+    assert.equal(result.order.metadata, '0x' + '0'.repeat(64));
+    assert.equal(result.order.builder, '0x' + '0'.repeat(64));
+
+    assert.throws(() =>
+      buildSignedOrderV2(
+        { tokenId: '21742633143463906290569050155826241533067272736897614950488156847949938836455', price: 0.5, size: 100, side: 'buy' },
+        { privateKey: TEST_PRIVATE_KEY, signatureType: SignatureType.POLY_1271 }
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #72's Polymarket audit. That PR fixed auth (header names + HMAC encoding) but left a documented gap: the order signer only ever produced V1-shaped orders, while V1 and V2 exchanges are both live simultaneously on-chain and `GET /version` on the live CLOB currently returns `2` — meaning V2 is the exchange-wide default order format right now.

- **New V2 order signer.** V2's `Order` struct drops `taker`/`expiration`/`nonce`/`feeRateBps` and adds `timestamp`/`metadata`/`builder` — verified against `ctf-exchange-v2`'s `Structs.sol`/`Hashing.sol` and `clob-client-v2`'s `exchangeOrderBuilderV2.ts` (both agree byte-for-byte on the EIP-712 type string). Proven **byte-identical** to an independent `ethers` EIP-712 signature across both the standard and negRisk exchange contracts.
- **Auto version detection.** `getCurrentPolymarketOrderVersion()` queries `GET /version` (5-min cache, falls back to 2 on failure — matching the official client's own fallback). Single and batch order placement now dispatch to whichever version is actually live instead of hardcoding V1.
- **Approval coverage.** Extended `approveUSDC`/`getUSDCAllowance` and the onboarding `getRequiredApprovals`/`checkAllApprovals` to cover all four exchange contracts (V1 + V2, standard + negRisk) — a correctly V2-signed order would otherwise fail at settlement from an allowance that only ever covered the V1 exchange.
- **POLY_1271 explicitly out of scope.** Smart-contract-wallet signing needs a different nested `TypedDataSign` wrapper, not a plain EIP-712 signature — `buildSignedOrderV2` throws a clear error if it's requested rather than silently producing an invalid signature.

## Test plan
- [x] `npm run typecheck` — clean, zero errors
- [x] `npm test` — 172/172 passing (3 new), V1 signing path untouched
- [x] New signer proven byte-identical to an independent `ethers` EIP-712 reference (not derived from the code under test) across standard-exchange/BUY and negRisk-exchange/SELL
- [x] Live-verified: `GET /version` currently returns 2; V2 exchange contracts have real, substantial on-chain bytecode; the produced order body's field shapes/lengths match Polymarket's documented wire format
- [ ] Funded-wallet smoke test (not possible in this environment — no live credentials, and this sandbox is geoblocked from Polymarket's live order endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)