### PR TITLE
fix: remaining lower-severity findings from the pump.fun/PumpSwap audit

### DIFF
--- a/src/agents/handlers/solana.ts
+++ b/src/agents/handlers/solana.ts
@@ -372,6 +372,46 @@ async function pumpfunChartHandler(toolInput: ToolInput): Promise<HandlerResult>
 }
 
 /**
+ * The on-chain create instruction just stores metadata_uri as an opaque
+ * string — it doesn't fetch or validate it, so a bad URI doesn't fail the
+ * transaction. It fails silently instead: a real, permanent, indexed token
+ * gets minted (at real cost — rent, plus any initial_buy_sol) with metadata
+ * that never loads anywhere. Catch that here, before spending anything,
+ * rather than after.
+ */
+async function validateMetadataUri(uri: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`metadata_uri is not a valid URL: "${uri}"`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`metadata_uri must be an http(s) URL (got "${parsed.protocol}"). Use an HTTPS gateway URL for IPFS/Arweave content (e.g. https://ipfs.io/ipfs/...), not a raw ipfs:// or ar:// URI.`);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(uri, { signal: AbortSignal.timeout(10_000) });
+  } catch (error) {
+    throw new Error(`metadata_uri is unreachable: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`metadata_uri returned HTTP ${response.status} — fix the URL before spending real SOL creating this token.`);
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    throw new Error('metadata_uri did not return valid JSON.');
+  }
+  if (typeof json !== 'object' || json === null || !('name' in json) || !('symbol' in json)) {
+    throw new Error('metadata_uri JSON is missing the required "name"/"symbol" fields pump.fun expects.');
+  }
+}
+
+/**
  * Builds and submits a real create (and optional initial-buy) transaction
  * locally via the official @pump-fun/pump-sdk — no third-party relay.
  *
@@ -391,6 +431,8 @@ async function pumpfunCreateHandler(toolInput: ToolInput): Promise<HandlerResult
   const initialBuySol = toolInput.initial_buy_sol as number | undefined;
 
   return safeHandler(async () => {
+    await validateMetadataUri(metadataUri);
+
     const { wallet } = await getSolanaModules();
     const keypair = wallet.loadSolanaKeypair();
     const connection = wallet.getSolanaConnection();
@@ -403,19 +445,31 @@ async function pumpfunCreateHandler(toolInput: ToolInput): Promise<HandlerResult
     const onlineSdk = new OnlinePumpSdk(connection);
     const global = await onlineSdk.fetchGlobal();
 
+    // createInstruction/createAndBuyInstructions are @deprecated in the SDK
+    // in favor of the V2 variants below — using the current, actively
+    // maintained path rather than one pump.fun could retire independently
+    // of the pinned SDK version, with no compile-time warning if they do.
+    // Note createV2Instruction/createV2AndBuyInstructions always mint under
+    // Token-2022 (TOKEN_2022_PROGRAM_ID), unconditionally, regardless of
+    // mayhemMode — that flag only toggles Mayhem-mode game mechanics, not
+    // the token program. mayhemMode: false here is a normal (non-Mayhem)
+    // Token-2022 launch, matching what pump.fun's own V2 creation flow
+    // produces today.
     let instructions;
     if (initialBuySol && initialBuySol > 0) {
       const solAmount = new BN(Math.floor(initialBuySol * 1e9));
       const amount = getBuyTokenAmountFromSolAmount({
         global, feeConfig: null, mintSupply: null, bondingCurve: null, amount: solAmount, quoteMint: PublicKey.default,
       });
-      instructions = await pumpSdk.createAndBuyInstructions({
+      instructions = await pumpSdk.createV2AndBuyInstructions({
         global, mint: mintKeypair.publicKey, name, symbol, uri: metadataUri,
         creator: keypair.publicKey, user: keypair.publicKey, amount, solAmount,
+        mayhemMode: false, cashback: false,
       });
     } else {
-      instructions = [await pumpSdk.createInstruction({
+      instructions = [await pumpSdk.createV2Instruction({
         mint: mintKeypair.publicKey, name, symbol, uri: metadataUri, creator: keypair.publicKey, user: keypair.publicKey,
+        mayhemMode: false, cashback: false,
       })];
     }
 

--- a/src/skills/bundled/pumpfun/index.ts
+++ b/src/skills/bundled/pumpfun/index.ts
@@ -1407,6 +1407,45 @@ Price: $${result.priceUsd?.toFixed(2) || result.price?.toFixed(2) || 'N/A'}`;
 // Creation Handlers
 // ============================================================================
 
+/**
+ * The on-chain create instruction just stores metadata_uri as an opaque
+ * string — a bad URI doesn't fail the transaction, it fails silently: a
+ * real, permanent, indexed token gets minted (at real cost) with metadata
+ * that never loads. Same validation as agents/handlers/solana.ts's
+ * pumpfunCreateHandler — catch it here before spending anything.
+ */
+async function validateMetadataUri(uri: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`metadata-uri is not a valid URL: "${uri}"`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`metadata-uri must be an http(s) URL (got "${parsed.protocol}"). Use an HTTPS gateway URL for IPFS/Arweave content, not a raw ipfs:// or ar:// URI.`);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(uri, { signal: AbortSignal.timeout(10_000) });
+  } catch (error) {
+    throw new Error(`metadata-uri is unreachable: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`metadata-uri returned HTTP ${response.status} — fix the URL before spending real SOL creating this token.`);
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    throw new Error('metadata-uri did not return valid JSON.');
+  }
+  if (typeof json !== 'object' || json === null || !('name' in json) || !('symbol' in json)) {
+    throw new Error('metadata-uri JSON is missing the required "name"/"symbol" fields pump.fun expects.');
+  }
+}
+
 async function handleCreate(args: string[]): Promise<string> {
   if (!isConfigured()) {
     return 'Pump.fun not configured. Set SOLANA_PRIVATE_KEY.';
@@ -1440,6 +1479,8 @@ Example:
   }
 
   try {
+    await validateMetadataUri(metadataUri);
+
     const { wallet } = await getSolanaModules();
     const walletKeypair = wallet.loadSolanaKeypair();
     const connection = wallet.getSolanaConnection();
@@ -1452,19 +1493,27 @@ Example:
     const onlineSdk = new OnlinePumpSdk(connection);
     const global = await onlineSdk.fetchGlobal();
 
+    // createInstruction/createAndBuyInstructions are @deprecated in the SDK
+    // in favor of the V2 variants below — see agents/handlers/solana.ts's
+    // pumpfunCreateHandler for the full rationale (same migration, same
+    // codebase-wide duplicated logic). createV2Instruction/
+    // createV2AndBuyInstructions always mint under Token-2022 regardless of
+    // mayhemMode; mayhemMode: false here is a normal (non-Mayhem) launch.
     let instructions;
     if (initialBuySol > 0) {
       const solAmount = new BN(Math.floor(initialBuySol * 1e9));
       const amount = getBuyTokenAmountFromSolAmount({
         global, feeConfig: null, mintSupply: null, bondingCurve: null, amount: solAmount, quoteMint: PublicKey.default,
       });
-      instructions = await pumpSdk.createAndBuyInstructions({
+      instructions = await pumpSdk.createV2AndBuyInstructions({
         global, mint: mintKeypair.publicKey, name, symbol, uri: metadataUri,
         creator: walletKeypair.publicKey, user: walletKeypair.publicKey, amount, solAmount,
+        mayhemMode: false, cashback: false,
       });
     } else {
-      instructions = [await pumpSdk.createInstruction({
+      instructions = [await pumpSdk.createV2Instruction({
         mint: mintKeypair.publicKey, name, symbol, uri: metadataUri, creator: walletKeypair.publicKey, user: walletKeypair.publicKey,
+        mayhemMode: false, cashback: false,
       })];
     }
 

--- a/src/solana/pumpapi.ts
+++ b/src/solana/pumpapi.ts
@@ -446,6 +446,29 @@ function getOnlinePumpSdk(connection: Connection): OnlinePumpSdk {
   return sdk;
 }
 
+/**
+ * fetchFeeConfig() legitimately has no account to find for a launch with no
+ * market-cap-tiered fee schedule configured — Anchor's account fetcher
+ * throws a plain Error whose message starts with "Account does not exist"
+ * for exactly that case (verified against
+ * node_modules/@coral-xyz/anchor/dist/cjs/program/namespace/account.js).
+ * That's the only case worth silently falling back to flat-rate fees for.
+ * Any OTHER failure — RPC timeout, connection reset, decode error — must
+ * not be treated the same way: silently substituting the flat rate for a
+ * transient failure would feed a wrong fee straight into real
+ * buy/sell-instruction math with no distinction from the legitimate case.
+ */
+async function fetchFeeConfigOrNull(onlineSdk: OnlinePumpSdk): Promise<Awaited<ReturnType<OnlinePumpSdk['fetchFeeConfig']>> | null> {
+  try {
+    return await onlineSdk.fetchFeeConfig();
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Account does not exist')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function detectTokenProgram(connection: Connection, mint: PublicKey): Promise<PublicKey> {
   const info = await connection.getAccountInfo(mint);
   if (!info) {
@@ -531,7 +554,7 @@ export async function buildPumpFunTradeInstructions(
 
   if (params.action === 'buy') {
     const [[global, feeConfig], { bondingCurveAccountInfo, bondingCurve, associatedUserAccountInfo }] = await Promise.all([
-      Promise.all([onlineSdk.fetchGlobal(), onlineSdk.fetchFeeConfig().catch(() => null)]),
+      Promise.all([onlineSdk.fetchGlobal(), fetchFeeConfigOrNull(onlineSdk)]),
       onlineSdk.fetchBuyState(mint, user, tokenProgram),
     ]);
 
@@ -561,7 +584,7 @@ export async function buildPumpFunTradeInstructions(
 
   // sell
   const [[global, feeConfig], { bondingCurveAccountInfo, bondingCurve }] = await Promise.all([
-    Promise.all([onlineSdk.fetchGlobal(), onlineSdk.fetchFeeConfig().catch(() => null)]),
+    Promise.all([onlineSdk.fetchGlobal(), fetchFeeConfigOrNull(onlineSdk)]),
     onlineSdk.fetchSellState(mint, user, tokenProgram),
   ]);
 
@@ -597,7 +620,7 @@ export async function executePumpFunTrade(
   // this RPC round-trip only after instruction-building finishes. Blockhash
   // validity is ~60-90s; shaving tens of ms off time-to-submission by
   // fetching it earlier is a clear net win, not a meaningful expiry risk.
-  const [{ instructions, solAmount }, { blockhash }] = await Promise.all([
+  const [{ instructions, solAmount }, { blockhash, lastValidBlockHeight }] = await Promise.all([
     buildPumpFunTradeInstructions(connection, keypair.publicKey, {
       mint: params.mint,
       action: params.action,
@@ -625,7 +648,7 @@ export async function executePumpFunTrade(
   }).compileToV0Message();
   const tx = new VersionedTransaction(message);
 
-  const signature = await signAndSendTransaction(connection, keypair, tx);
+  const signature = await signAndSendTransaction(connection, keypair, tx, lastValidBlockHeight);
 
   return { signature, endpoint: `local:@pump-fun/pump-sdk (${params.action} ${solAmount.toString()} lamports-equiv)` };
 }
@@ -668,7 +691,7 @@ export async function getPumpFunQuote(params: {
     // bonding-curve fetch below (or each other) — fire all three together.
     const [global, feeConfig, { bondingCurve }] = await Promise.all([
       onlineSdk.fetchGlobal(),
-      onlineSdk.fetchFeeConfig().catch(() => null),
+      fetchFeeConfigOrNull(onlineSdk),
       onlineSdk.fetchBuyState(mint, probeUser, tokenProgram),
     ]);
 

--- a/src/solana/pumpswap.ts
+++ b/src/solana/pumpswap.ts
@@ -271,7 +271,7 @@ export async function executePumpSwapTrade(
     // getLatestBlockhash doesn't depend on pool state (or vice versa) — fire
     // both concurrently rather than paying for this RPC round-trip only
     // after pool discovery/state-fetch finishes.
-    const [{ poolKey, state }, { blockhash }] = await Promise.all([
+    const [{ poolKey, state }, { blockhash, lastValidBlockHeight }] = await Promise.all([
       findBestPumpSwapState(connection, baseMint, quoteMintKey, keypair.publicKey),
       connection.getLatestBlockhash('confirmed'),
     ]);
@@ -282,7 +282,18 @@ export async function executePumpSwapTrade(
 
     const allInstructions = [...instructions];
     if (params.priorityFeeLamports) {
-      const computeUnitLimit = 200_000;
+      // PumpSwap trades can bundle extendAccount (pre-POOL_ACCOUNT_NEW_SIZE
+      // pools), ATA creation, WSOL wrap/sync/close, and boost/cashback
+      // remaining accounts on top of the base buy/sell instruction — a
+      // worst-case combination of all of those can exceed a plain 200k CU
+      // budget. This only matters when a caller opts into a priority fee at
+      // all (this whole block is skipped otherwise, falling back to
+      // Solana's default per-transaction compute budget); microLamports is
+      // derived FROM priorityFeeLamports/computeUnitLimit below, so raising
+      // this doesn't change the actual lamports spent on priority fee — the
+      // total (microLamports * computeUnitLimit) is priorityFeeLamports by
+      // construction either way, just spread over more CU headroom.
+      const computeUnitLimit = 400_000;
       const microLamports = Math.max(1, Math.floor((params.priorityFeeLamports * 1_000_000) / computeUnitLimit));
       allInstructions.unshift(
         ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnitLimit }),
@@ -297,7 +308,7 @@ export async function executePumpSwapTrade(
     }).compileToV0Message();
     const tx = new VersionedTransaction(message);
 
-    const signature = await signAndSendTransaction(connection, keypair, tx);
+    const signature = await signAndSendTransaction(connection, keypair, tx, lastValidBlockHeight);
 
     return { success: true, txHash: signature, poolAddress: poolKey.toBase58() };
   } catch (error) {

--- a/src/solana/swarm-builders.ts
+++ b/src/solana/swarm-builders.ts
@@ -231,7 +231,13 @@ export class PumpSwapBuilder implements SwarmTransactionBuilder {
 
     const allInstructions = [...instructions];
     if (options.priorityFeeLamports) {
-      const computeUnitLimit = 200_000;
+      // See executePumpSwapTrade in pumpswap.ts for the full rationale —
+      // PumpSwap's worst-case instruction bundle (extendAccount + ATA +
+      // WSOL wrap/close + boost accounts) can exceed a plain 200k CU
+      // budget; raising this doesn't change actual lamports spent on
+      // priority fee, since microLamports is derived from
+      // priorityFeeLamports/computeUnitLimit below.
+      const computeUnitLimit = 400_000;
       const microLamports = Math.max(1, Math.floor((options.priorityFeeLamports * 1_000_000) / computeUnitLimit));
       allInstructions.unshift(
         ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnitLimit }),

--- a/src/solana/wallet.ts
+++ b/src/solana/wallet.ts
@@ -74,15 +74,23 @@ export async function signAndSendVersionedTransaction(
 export async function signAndSendTransaction(
   connection: Connection,
   keypair: Keypair,
-  transaction: Transaction | VersionedTransaction
+  transaction: Transaction | VersionedTransaction,
+  /**
+   * The lastValidBlockHeight that actually corresponds to the blockhash
+   * already baked into transaction's message — pass this when the caller
+   * fetched that blockhash itself before building the message (every
+   * pump.fun call site does, since blockhash-fetch is parallelized with
+   * instruction-building). Without it, this falls back to fetching a NEW
+   * blockhash's height purely to have *a* number to confirm against — which
+   * doesn't correspond to the height this specific already-signed
+   * transaction actually expires at, and can make confirmTransaction poll
+   * longer than necessary before detecting a genuine expiry. Fail-safe
+   * either way (never reports false success/failure), just a latency
+   * difference in the already-rare true-expiry case.
+   */
+  lastValidBlockHeight?: number
 ): Promise<string> {
   if (transaction instanceof VersionedTransaction) {
-    // Fetch a fresh blockhash for confirmation rather than reusing whatever
-    // was baked into the transaction's own message: the tx's own blockhash
-    // may have been fetched a while ago (e.g. concurrently with instruction
-    // building), and confirming against an already-stale lastValidBlockHeight
-    // would make confirmTransaction think the tx is still within its window
-    // after it has actually already expired.
     transaction.sign([keypair]);
     const raw = transaction.serialize();
     const signature = await connection.sendRawTransaction(raw, {
@@ -91,15 +99,21 @@ export async function signAndSendTransaction(
     });
 
     // Confirm to detect on-chain failures
-    const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
-    const result = await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, 'confirmed');
+    const blockhash = transaction.message.recentBlockhash;
+    const height = lastValidBlockHeight ?? (await connection.getLatestBlockhash('confirmed')).lastValidBlockHeight;
+    const result = await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight: height }, 'confirmed');
     assertConfirmedOk(signature, result);
 
     return signature;
   }
 
+  // Legacy Transaction always gets a freshly-fetched blockhash right here
+  // (unlike VersionedTransaction above, it isn't pre-built by the caller
+  // with its own blockhash already baked in), so this height genuinely
+  // does correspond to what's being signed — no staleness concern, and the
+  // lastValidBlockHeight parameter isn't relevant to this branch.
   transaction.feePayer = keypair.publicKey;
-  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
+  const { blockhash, lastValidBlockHeight: legacyLastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
   transaction.recentBlockhash = blockhash;
   transaction.sign(keypair);
   const signature = await connection.sendRawTransaction(transaction.serialize(), {
@@ -108,7 +122,7 @@ export async function signAndSendTransaction(
   });
 
   // Confirm to detect on-chain failures
-  const result = await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, 'confirmed');
+  const result = await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight: legacyLastValidBlockHeight }, 'confirmed');
   assertConfirmedOk(signature, result);
 
   return signature;


### PR DESCRIPTION
## Summary
Closes out all five items deliberately deferred from the previous audit PR (#84), one by one:

1. **fetchFeeConfig error swallowing** — no longer treats every failure as "no fee tiers configured"; only Anchor's own "Account does not exist" error gets that treatment now, any other failure (RPC timeout, etc.) propagates instead of silently feeding a wrong fee into real trade math.
2. **Deprecated create methods** — migrated to `createV2Instruction`/`createV2AndBuyInstructions`. Note: the V2 path always mints under Token-2022 now (a real behavior change from the legacy classic-SPL path), matching what pump.fun's own current creation flow produces.
3. **metadata_uri validation** — URL shape, reachability, and JSON-shape checks before any RPC calls, so a bad URI is rejected before spending real SOL rather than silently minting a token with permanently broken metadata.
4. **PumpSwap compute-unit headroom** — raised 200k → 400k for PumpSwap trades specifically (bonding-curve trades left at 200k, since the worst-case-bundle concern is PumpSwap-specific). Confirmed this doesn't increase actual priority-fee cost — the limit and the derived per-unit price cancel out to the caller's requested total either way.
5. **Blockhash-freshness mismatch** — `signAndSendTransaction` now accepts the real `lastValidBlockHeight` from callers that already have it (both pump.fun trade paths), instead of always re-fetching a mismatched one. Fully backward compatible for every other caller.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 172/172 passing
- [x] Live-verified each fix individually against mainnet as it landed (fee-config happy path, both V2 create instruction builders, all metadata_uri validation branches including the happy path, and the full CU-limit + blockhash-threading path end-to-end for both `executePumpFunTrade` and `executePumpSwapTrade`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)