### PR TITLE
fix: Jupiter limit orders were completely broken by a missing @trpc/server peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@slack/bolt": "^3.17.1",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
+        "@trpc/server": "10.45.4",
         "@types/better-sqlite3": "^7.6.13",
         "@types/bn.js": "^5.2.0",
         "@types/figlet": "^1.7.0",
@@ -9622,6 +9623,15 @@
       "peerDependencies": {
         "@trpc/server": "10.45.4"
       }
+    },
+    "node_modules/@trpc/server": {
+      "version": "10.45.4",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.45.4.tgz",
+      "integrity": "sha512-5MuyK5sDuFVGHOT9EMVHgRjP5I5j3RqGymcb5D47UOp8tzn6LH0g1lEgYrAsOZ12vmk1gpxMw/v/y4xHHK/Qdg==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT"
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@slack/bolt": "^3.17.1",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
+    "@trpc/server": "10.45.4",
     "@types/better-sqlite3": "^7.6.13",
     "@types/bn.js": "^5.2.0",
     "@types/figlet": "^1.7.0",

--- a/src/solana/jupiter.ts
+++ b/src/solana/jupiter.ts
@@ -243,7 +243,18 @@ export async function executeJupiterSwap(
   const txBytes = Buffer.from(swapJson.swapTransaction, 'base64');
   const signature = await signAndSendVersionedTransaction(connection, keypair, new Uint8Array(txBytes));
 
-  return { signature, quote, endpoint: baseUrl };
+  return {
+    signature,
+    quote,
+    endpoint: baseUrl,
+    // Flat convenience fields mirroring the quote — several callers (e.g. the
+    // /jup and /sol skill commands) read these at the top level per the
+    // JupiterSwapResult contract instead of reaching into `quote`.
+    inAmount: quote.inAmount,
+    outAmount: quote.outAmount,
+    priceImpactPct: quote.priceImpactPct,
+    routePlan: quote.routePlan,
+  };
 }
 
 // ============================================================================
@@ -732,7 +743,19 @@ export async function listJupiterLimitOrdersByMint(
     filters.push(outputMintFilter(new PublicKey(options.outputMint)));
   }
 
-  const orders = await provider.getOrders(filters.length > 0 ? filters : undefined);
+  if (filters.length === 0) {
+    // provider.getOrders() with no filters does an unfiltered
+    // program.account.order.all() — a full getProgramAccounts scan of every
+    // open limit order on the entire Jupiter Limit Order program across all
+    // users, not just this caller's. Refuse rather than silently fetching
+    // (and decoding) every order on mainnet.
+    throw new Error(
+      'listJupiterLimitOrdersByMint requires at least one of owner, inputMint, or outputMint — ' +
+      'calling it with no filters would fetch every open Jupiter limit order on mainnet.'
+    );
+  }
+
+  const orders = await provider.getOrders(filters);
 
   return orders.map((order) => ({
     publicKey: order.publicKey.toBase58(),


### PR DESCRIPTION
## Summary

Audit of Jupiter's swap aggregator integration (`src/solana/jupiter.ts`), part of the ongoing Solana venue-integration coverage pass. The headline finding is severe: **every Jupiter limit-order function was completely non-functional**, plus two smaller live-verified fixes in the same file.

- **All limit-order operations threw on the very first call.** `createJupiterLimitOrder`, `cancelJupiterLimitOrder`, `batchCancelJupiterLimitOrders`, `listJupiterLimitOrders`, `getJupiterLimitOrder`, `getJupiterLimitOrderHistory`, `getJupiterLimitOrderFee`, `getJupiterTradeHistory`, `cancelExpiredJupiterLimitOrder`, `batchCancelExpiredJupiterLimitOrders`, and `listJupiterLimitOrdersByMint` all dynamically import `@jup-ag/limit-order-sdk`, which `require()`s `@trpc/client` at module load time, which declares `@trpc/server` as a **peer dependency** — never installed anywhere in this repo (checked both `package.json` and `package-lock.json`). Confirmed directly: `node -e "require('@jup-ag/limit-order-sdk')"` threw `Cannot find module '@trpc/server/observable'` every time. So every one of those eleven exported functions rejected immediately, before ever touching Solana or a wallet. Pinned `@trpc/server` to the exact peer version (`10.45.4`) `@trpc/client` needs. After installing it, live calls against the real Jupiter Limit Order program on mainnet succeed and decode correctly (`getJupiterLimitOrderFee` → real on-chain fee PDA: `makerFee: 10, makerStableFee: 1, ...`; `listJupiterLimitOrders` → real owner-filtered `getProgramAccounts` round-trip with no decode errors).

- **`executeJupiterSwap`'s return value silently dropped half its declared fields.** `JupiterSwapResult` declares top-level `inAmount`/`outAmount`/`priceImpactPct`/`routePlan`, but the function only ever returned `{ signature, quote, endpoint }` — those fields were never populated. Two call sites (`/jup swap` and `/sol swap` skill commands) read them at the top level per the type contract, so a real swap's summary output always rendered `undefined`/`undefined`/`N/A`/`Direct` for amount in, amount out, price impact, and route — only the signature was ever correct. `src/solana/copytrade.ts` worked around this correctly by reaching into `result.quote` instead, which is how the bug was found (comparing that call site's workaround against the other two that didn't). Now populated from the quote.

- **`listJupiterLimitOrdersByMint` had a latent unbounded-fetch footgun.** When called with none of `owner`/`inputMint`/`outputMint`, it fell back to `provider.getOrders()` with an empty filter array, which does an unfiltered `program.account.order.all()` — a full `getProgramAccounts` scan of *every* open limit order on the entire Jupiter Limit Order program (all users, not just the caller). No current call site hits this today (both existing callers always pass `owner`), but it's an exported function one filter-check short of the same unbounded-fetch bug class already guarded against in `meteora-dbc.ts`'s `getDbcPools()`. Now throws instead of silently fetching everything.

Also checked and found clean, no changes needed:
- The REST swap endpoints (`lite-api.jup.ag/swap/v1/quote`, `/swap`, `/swap-instructions`, `/program-id-to-label`) are all live and responding correctly — not a deprecated/sunset API generation.
- The on-chain DCA program (`DCA265Vj8...`) and Limit Order program (`jupoNjAxX...`) are both live and actively used on mainnet (signatures within the hour at time of testing) — not dead hosts.
- Every tx-send path in the file (`executeJupiterSwap` via `signAndSendVersionedTransaction`; all limit-order/DCA mutations via `signAndSendTransaction`) already routes through the shared `wallet.ts` helper — no hand-rolled `sendRawTransaction`.
- `@jup-ag/api` is listed as a dependency but never imported anywhere in the codebase (dead dependency, left as-is — out of scope to remove/wire up in this PR).

## Test plan

- `npm run typecheck` — clean
- `npm run test` — 169/169 passing
- `npm run build` — clean
- Live-verified against real mainnet (scratch scripts deleted, not part of this diff):
  - `require('@jup-ag/limit-order-sdk')` — threw before the `@trpc/server` fix, loads clean after.
  - `getJupiterLimitOrderFee` against the real on-chain fee PDA — correct values.
  - `listJupiterLimitOrders` (owner-filtered `getProgramAccounts`) and `listJupiterDCAs` / `getJupiterDCAAvailableTokens` — round-trip and decode without error against mainnet.
  - `curl` against `lite-api.jup.ag/swap/v1/quote`, `/swap-instructions`, `/program-id-to-label` — all respond correctly.
  - Confirmed both the DCA and Limit Order on-chain programs have recent (sub-hour) transaction activity on mainnet.