### PR TITLE
fix: pump.fun graduation detection couldn't resolve the PumpSwap pool address

### DIFF
--- a/src/solana/pumpapi.ts
+++ b/src/solana/pumpapi.ts
@@ -30,6 +30,7 @@ import {
   getSellSolAmountFromTokenAmount,
 } from '@pump-fun/pump-sdk';
 import { signAndSendTransaction } from './wallet';
+import { findPumpSwapPools } from './pumpswap';
 import BN from 'bn.js';
 
 // ============================================================================
@@ -786,6 +787,8 @@ export async function getTokenInfo(mint: string): Promise<PumpTokenInfo | null> 
 // Graduation Check
 // ============================================================================
 
+const WSOL_MINT = new PublicKey('So11111111111111111111111111111111111111112');
+
 /**
  * Check if a token has graduated to PumpSwap
  */
@@ -796,13 +799,31 @@ export async function isGraduated(
   const state = await getBondingCurveState(connection, mint);
 
   if (state?.complete) {
-    // Try to get PumpSwap pool from API
-    const mintStr = typeof mint === 'string' ? mint : mint.toBase58();
-    const info = await getTokenInfo(mintStr);
-    return {
-      graduated: true,
-      pumpswapPool: info?.pumpswapPool,
-    };
+    const mintPk = typeof mint === 'string' ? new PublicKey(mint) : mint;
+
+    // getTokenInfo() hits pump.fun's frontend API directly, which sits
+    // behind Cloudflare bot-protection that blocks non-browser requests —
+    // confirmed live: a real, long-graduated token's bonding curve
+    // correctly parses as complete:true here, but getTokenInfo() returned
+    // null every time (Cloudflare challenge page, not the real JSON), so
+    // pumpswapPool was always undefined regardless of whether the token
+    // had actually graduated. findPumpSwapPools() resolves the same
+    // information directly from on-chain program accounts — the same
+    // mechanism pumpswap.ts's own trading functions already rely on — so
+    // try that first and only fall back to the frontend API (which may
+    // have richer metadata when it *does* work) if it comes up empty.
+    let pumpswapPool: string | undefined;
+    try {
+      const pools = await findPumpSwapPools(connection, mintPk, WSOL_MINT);
+      pumpswapPool = pools[0]?.toBase58();
+    } catch { /* fall through to the frontend-API attempt below */ }
+
+    if (!pumpswapPool) {
+      const info = await getTokenInfo(mintPk.toBase58());
+      pumpswapPool = info?.pumpswapPool;
+    }
+
+    return { graduated: true, pumpswapPool };
   }
 
   return { graduated: false };


### PR DESCRIPTION
## Summary

Continues this session's pump.fun/PumpSwap work — audit of the graduation ("edge") detection between the pump.fun bonding curve and PumpSwap.

`isGraduated()`'s `pumpswapPool` field was always `undefined` in practice. `getTokenInfo()` hits pump.fun's `frontend-api-v3.pump.fun` endpoint directly, which sits behind Cloudflare bot-protection that blocks non-browser requests. Confirmed live against a real, long-graduated token (mint `9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump`): its bonding curve correctly parsed as `complete: true` — **the core graduation-boundary detection itself was already correct** (the account isn't closed on graduation, it persists on-chain with `complete: true`) — but `getTokenInfo()` returned `null` every time due to the Cloudflare block, so `pumpswapPool` came back `undefined` regardless of whether the token had actually graduated.

Fixed by trying `findPumpSwapPools()` (from `pumpswap.ts`, an already-proven on-chain program-account lookup that file's own trading functions already rely on) first, falling back to the frontend API only if that comes up empty. Live-verified end to end: `isGraduated()` now returns a real pool address (`ECE2mWMQZUa8i8qGchuSAB66QzDN3WUhhtGRMbgNL3L`), independently confirmed to be a real account owned by the actual PumpSwap program (`pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA`). `getBestPool()` automatically inherits the fix since it just forwards `isGraduated()`'s result.

**Related, non-blocking follow-up not addressed here:** cross-checking the official `@pump-fun/pump-sdk`'s real `BondingCurve` type shows the hand-rolled byte-offset parser in `parseBondingCurveState()` is missing two real on-chain fields — `creator: PublicKey` (byte 49) and `quoteMint: PublicKey` (later in the struct) — that exist in the actual account layout. The `complete` flag and reserve fields it does parse are byte-offset-correct, but any bonding curve whose `quoteMint` isn't native SOL (e.g. certain Mayhem-mode/cashback-coin curves, which the parser already has partial awareness of via `isMayhemMode`) would have its `virtualSolReserves`/`realSolReserves` fields silently misinterpreted as SOL when they're actually a different quote asset.

## Test plan

- `npm run typecheck` — clean
- `npm run test` — 172/172 passing
- Live-verified against real mainnet (scratch scripts deleted, not part of this diff):
  - Confirmed a real graduated token's bonding curve account persists on-chain with `complete: true` (not closed on migration).
  - Confirmed `getTokenInfo()` returns `null` for this token due to Cloudflare blocking.
  - Confirmed `isGraduated()` now resolves a real `pumpswapPool` address via the on-chain fallback, independently verified to be owned by the real PumpSwap program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)