### PR TITLE
fix: swarm stop-loss/take-profit and 'auto' DEX routing didn't account for graduation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13584,12 +13584,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-ftp": {
@@ -14075,9 +14078,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -14094,11 +14097,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -14382,9 +14385,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001766",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15355,9 +15358,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.283",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
-      "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
+      "version": "1.5.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
+      "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -20009,10 +20012,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "license": "MIT"
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nodemailer": {
       "version": "9.0.6",
@@ -23717,9 +23723,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/solana/pump-swarm.ts
+++ b/src/solana/pump-swarm.ts
@@ -230,12 +230,12 @@ import {
   DexType,
   SwarmWallet as BuilderSwarmWallet,
 } from './swarm-builders';
+import { getBondingCurveState, calculatePrice } from './pumpapi';
 
 // ============================================================================
 // Constants
 // ============================================================================
 
-const PUMPFUN_FRONTEND_API = 'https://frontend-api-v3.pump.fun';
 const JITO_BLOCK_ENGINE = 'https://mainnet.block-engine.jito.wtf';
 const JITO_TIP_ACCOUNTS = [
   '96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5',
@@ -945,7 +945,7 @@ export class PumpFunSwarm extends EventEmitter {
   ): Promise<VersionedTransaction | null> {
     // Get the appropriate builder for the DEX
     const dex: DexType = params.dex ?? 'pumpfun';
-    const builder = getBuilder(dex);
+    const builder = await getBuilder(dex, this.connection, params.mint);
 
     const options: BuilderOptions = {
       slippageBps: params.slippageBps ?? this.config.defaultSlippageBps,
@@ -1482,7 +1482,7 @@ export class PumpFunSwarm extends EventEmitter {
 
     // Get the builder for the specified DEX
     const dex: DexType = params.dex ?? 'pumpfun';
-    const builder = getBuilder(dex);
+    const builder = await getBuilder(dex, this.connection, params.mint);
 
     for (const wallet of wallets) {
       try {
@@ -1759,23 +1759,53 @@ export class PumpFunSwarm extends EventEmitter {
 
     for (const mint of mints) {
       try {
-        // Get current price from Pump.fun frontend API
-        const priceHeaders: Record<string, string> = {
-          'Accept': 'application/json',
-          'Origin': 'https://pump.fun',
-        };
-        const jwt = process.env.PUMPFUN_JWT;
-        if (jwt) {
-          priceHeaders['Authorization'] = `Bearer ${jwt}`;
+        // Was fetched from Pump.fun's frontend API, which sits behind
+        // Cloudflare bot-protection that blocks non-browser requests
+        // (confirmed live elsewhere this session — see isGraduated()'s fix
+        // in pumpapi.ts). On a block, `!response.ok` silently `continue`d
+        // with no log line at all, meaning stop-loss/take-profit could
+        // stop firing entirely with zero trace. The raw
+        // solReserves/tokenReserves ratio computed here was also never
+        // decimal-adjusted (SOL has 9 decimals, pump.fun tokens have 6) —
+        // off from a real per-token price by ~1000x, so even when the API
+        // call succeeded, triggerPrice comparisons (documented/configured
+        // in real, human-scale SOL-per-token terms, e.g. the `/swarm
+        // stop-loss` command's own usage example of 0.00001) were
+        // comparing against the wrong magnitude entirely. Reading the
+        // bonding curve directly on-chain and using calculatePrice()
+        // (already decimal-correct, matches getTokenPriceInfo()'s
+        // convention) fixes both problems at once.
+        const state = await getBondingCurveState(this.connection, mint);
+        if (!state) {
+          logger.warn({ mint }, 'Price trigger check: bonding curve not found (token may not exist yet, or has already fully migrated off-chain)');
+          continue;
         }
-        const response = await fetch(`${PUMPFUN_FRONTEND_API}/coins/${mint}`, { headers: priceHeaders });
-        if (!response.ok) continue;
 
-        const data = await response.json() as { market_cap?: number; virtual_sol_reserves?: number; virtual_token_reserves?: number; usd_market_cap?: number };
-        // Estimate price from reserves: price ≈ solReserves / tokenReserves
-        const solReserves = data.virtual_sol_reserves ?? 0;
-        const tokenReserves = data.virtual_token_reserves ?? 0;
-        const currentPrice = (solReserves > 0 && tokenReserves > 0) ? solReserves / tokenReserves : undefined;
+        // The bonding curve account isn't closed on graduation (confirmed
+        // live elsewhere this session, see isGraduated()'s fix) — but its
+        // reserves are FROZEN at their final pre-graduation values once
+        // trading moves to PumpSwap. calculatePrice(state) on a graduated
+        // curve would silently return that stale, frozen price forever
+        // instead of tracking the real, live PumpSwap price — the same
+        // "doesn't account for the post-graduation state transition" bug
+        // class as isGraduated()/getBuilder('auto'), recurring here.
+        let currentPrice: number;
+        if (state.complete) {
+          try {
+            const { findBestPumpSwapState } = await import('./pumpswap');
+            const baseMint = new PublicKey(mint);
+            const quoteMint = new PublicKey('So11111111111111111111111111111111111111112'); // WSOL, matches pumpswap.ts's/PumpSwapBuilder's default
+            const { state: poolState } = await findBestPumpSwapState(this.connection, baseMint, quoteMint, SystemProgram.programId);
+            const quoteSol = poolState.poolQuoteAmount.toNumber() / 1e9;
+            const baseTokens = poolState.poolBaseAmount.toNumber() / 1e6; // pump.fun tokens are always 6dp
+            currentPrice = baseTokens > 0 ? quoteSol / baseTokens : 0;
+          } catch (err) {
+            logger.warn({ mint, err }, 'Price trigger check: graduated token, but no PumpSwap pool found (or lookup failed) — skipping this cycle');
+            continue;
+          }
+        } else {
+          currentPrice = calculatePrice(state);
+        }
         if (!currentPrice) continue;
 
         // Check stop loss

--- a/src/solana/swarm-builders.ts
+++ b/src/solana/swarm-builders.ts
@@ -641,9 +641,35 @@ builders.set('pumpswap', new PumpSwapBuilder());
 builders.set('bags', new BagsBuilder());
 builders.set('meteora', new MeteoraBuilder());
 
-export function getBuilder(dex: DexType): SwarmTransactionBuilder {
+/**
+ * `dex: 'auto'` used to unconditionally resolve to PumpFunBuilder (the
+ * bonding-curve builder) regardless of whether the token had actually
+ * graduated — 'auto' didn't do what its name promised, and the deeper
+ * pool: 'auto' option threaded through to buildPumpFunTradeInstructions
+ * (see assertSupportedPumpPool in pumpapi.ts) is treated identically to
+ * pool: 'pump' there too, so there was no real auto-routing anywhere in
+ * this call chain. A trade against a graduated token would only fail
+ * loudly via that function's own graduated-token guard, never actually
+ * route to PumpSwap. Reachable in practice via the `/swarm buy`/`/swarm
+ * sell --dex auto` skill flag (type-allowed, if undocumented in the
+ * printed help text).
+ */
+export async function getBuilder(
+  dex: DexType,
+  connection?: Connection,
+  mint?: string
+): Promise<SwarmTransactionBuilder> {
   if (dex === 'auto') {
-    // Default to pumpfun for auto
+    if (connection && mint) {
+      const { getBestPool } = await import('./pumpapi');
+      const { pool } = await getBestPool(connection, mint);
+      return builders.get(pool === 'pump-amm' ? 'pumpswap' : 'pumpfun')!;
+    }
+    // No connection/mint to check graduation with (e.g. a caller building
+    // a quote-only estimate with no live RPC context) — pumpfun remains a
+    // reasonable default, but this can no longer silently misroute a real
+    // trade against a graduated token when the caller does have that
+    // context, which every real call site in pump-swarm.ts does.
     return builders.get('pumpfun')!;
   }
 


### PR DESCRIPTION
## Summary

Continues the pump.fun/PumpSwap edge-case audit that started with `isGraduated()`'s pool-resolution fix. Two confirmed, live-verified bugs.

- **`checkPriceTriggers()`** (`src/solana/pump-swarm.ts`) was hitting the same Cloudflare-blocked pump.fun frontend API `isGraduated()` was fixed for earlier this session. On a block, `!response.ok` silently `continue`d with zero logging — swarm stop-loss/take-profit could stop firing entirely with no trace. The old raw `solReserves/tokenReserves` ratio was also never decimal-adjusted (SOL 9dp vs pump.fun tokens 6dp) — off from a real per-token price by ~1000x, even when the API call succeeded, against `triggerPrice` values documented in real SOL-per-token terms (e.g. `/swarm stop-loss`'s own usage example of `0.00001`).

  Fixed by reading the bonding curve directly on-chain via `getBondingCurveState()`/`calculatePrice()` (both already exist in `pumpapi.ts`, decimal-correct). **A design-review pass then caught a third, more subtle bug in that fix before it shipped**: the bonding curve account isn't closed on graduation, but its reserves freeze at their final pre-migration values once trading moves to PumpSwap — `calculatePrice()` on a graduated token would have silently returned a stale/zero price forever, meaning a stop-loss/take-profit surviving a token's graduation would stop tracking the real price. Live-verified against the real graduated mint `9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump`: the bonding-curve price resolves to `0` (frozen/zeroed reserves), while the correct live PumpSwap price is `0.00173` SOL/token. Fixed by branching on `state.complete`: non-graduated uses `calculatePrice()`, graduated resolves live price from `findBestPumpSwapState()` (`pumpswap.ts`) instead.

- **`getBuilder('auto')`** (`src/solana/swarm-builders.ts`) always returned `PumpFunBuilder` regardless of whether the token had graduated — `'auto'` didn't do what its name promised, and the deeper `pool: 'auto'` option threaded through to `buildPumpFunTradeInstructions` is treated identically to `pool: 'pump'` there too (`assertSupportedPumpPool` in `pumpapi.ts`), so there was no real auto-routing anywhere in this call chain. Reachable in practice via the `/swarm buy`/`/swarm sell --dex auto` skill flag (type-allowed, though undocumented in the printed help text). Fixed: `getBuilder` is now async, takes optional `connection`/`mint`, and checks `getBestPool()` when `dex === 'auto'` to pick `PumpFunBuilder` vs `PumpSwapBuilder`. Both call sites in `pump-swarm.ts` updated. Live-verified against both a real active mint (routes to `PumpFunBuilder`) and the real graduated mint above (routes to `PumpSwapBuilder`); the no-context fallback (no `connection`/`mint` available) still safely defaults to `PumpFunBuilder`.

## Test plan

- `npm run typecheck` — clean
- `npm run test` — 172/172 passing
- Live-verified against real mainnet (scratch scripts deleted, not part of this diff):
  - Routing tested against both a real active mint and the real graduated mint, both route correctly.
  - Price resolution tested against the graduated mint, confirming the stale-price bug and its fix (0.00173 SOL/token live vs 0 stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)