### PR TITLE
fix: /pump holders and sol-price depended on Cloudflare-blocked APIs; honest error for the rest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13584,12 +13584,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-ftp": {
@@ -14075,9 +14078,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -14094,11 +14097,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -14382,9 +14385,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001766",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15355,9 +15358,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.283",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
-      "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
+      "version": "1.5.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
+      "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -20009,10 +20012,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "license": "MIT"
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nodemailer": {
       "version": "9.0.6",
@@ -23717,9 +23723,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/skills/bundled/pumpfun/index.ts
+++ b/src/skills/bundled/pumpfun/index.ts
@@ -130,6 +130,25 @@ async function pumpFrontendRequest<T>(endpoint: string, baseUrl: string = PUMPFU
   const response = await fetch(`${baseUrl}${endpoint}`, { headers });
 
   if (!response.ok) {
+    // Both frontend-api-v3.pump.fun and advanced-api-v2.pump.fun sit
+    // behind Cloudflare bot-protection that blocks non-browser requests —
+    // confirmed live: every endpoint on both hosts returns a 403 with an
+    // HTML challenge/redirect page (not JSON) from a server-side
+    // environment like this one. Detect that specifically (rather than
+    // relabeling every non-403, e.g. a genuine 404 for an unknown mint,
+    // as "blocked") so the error tells the user what's actually true and
+    // there's no realistic per-request fix — no API key or header
+    // combination bypasses Cloudflare bot-protection from server-side code.
+    if (response.status === 403) {
+      const contentType = response.headers.get('content-type') || '';
+      if (!contentType.includes('application/json')) {
+        throw new Error(
+          "pump.fun's data API is blocking this request (Cloudflare bot-protection blocks non-browser requests) — " +
+          'this is not fixable per-request; commands relying on token discovery/listing/search/chart data from ' +
+          'pump.fun directly are currently unavailable from this server.'
+        );
+      }
+    }
     throw new Error(`Pump.fun API error: ${response.status}`);
   }
 
@@ -942,7 +961,14 @@ async function handleHolders(mint: string): Promise<string> {
   }
 
   try {
-    const holders = await pumpAdvancedRequest<PumpHolder[]>(`/coins/top-holders-and-sol-balance/${mint}`);
+    // advanced-api-v2.pump.fun (used here previously) is Cloudflare-blocked
+    // from server-side requests, confirmed live — every endpoint on that
+    // host returns HTTP 403. getTokenLargestAccounts is a standard Solana
+    // RPC method, fully on-chain, same top-20 ceiling the old endpoint had
+    // anyway.
+    const { wallet, pumpapi } = await getSolanaModules();
+    const connection = wallet.getSolanaConnection();
+    const holders = await pumpapi.getPumpTokenHolders(connection, mint);
 
     if (!holders?.length) return 'No holder data available.';
 
@@ -1394,10 +1420,18 @@ async function handleLatestTrades(args: string[]): Promise<string> {
 
 async function handleSolPrice(): Promise<string> {
   try {
-    const result = await pumpFrontendRequest<{ price: number; priceUsd: number }>('/sol-price');
+    // frontend-api-v3.pump.fun (used here previously) is Cloudflare-blocked
+    // from server-side requests, confirmed live. Binance's own price feed
+    // (already used elsewhere in this codebase) has no such dependency and
+    // is a better source for SOL/USD specifically anyway.
+    const { getSOLPrice } = await import('../../../feeds/crypto');
+    const price = await getSOLPrice();
+    if (price === null) {
+      return 'Error: Could not fetch SOL price from any source.';
+    }
     return `**SOL Price**
 
-Price: $${result.priceUsd?.toFixed(2) || result.price?.toFixed(2) || 'N/A'}`;
+Price: $${price.toFixed(2)}`;
   } catch (error) {
     return `Error: ${error instanceof Error ? error.message : String(error)}`;
   }

--- a/src/solana/pumpapi.ts
+++ b/src/solana/pumpapi.ts
@@ -90,6 +90,8 @@ export interface BondingCurveState {
   tokenTotalSupply: BN;
   /** Whether the bonding curve is complete (graduated) */
   complete: boolean;
+  /** The token's creator (fee recipient) */
+  creator: PublicKey;
   /** Whether this is a mayhem mode token (Token2022) */
   isMayhemMode?: boolean;
 }
@@ -199,6 +201,12 @@ export function parseBondingCurveState(data: Buffer): BondingCurveState | null {
   const realSolReserves = new BN(data.subarray(32, 40), 'le');
   const tokenTotalSupply = new BN(data.subarray(40, 48), 'le');
   const complete = data[48] === 1;
+  // creator: Pubkey (32 bytes) immediately follows complete — verified
+  // against the official SDK's real BondingCurve type (which lists
+  // creator right after complete) and against this parser's own existing
+  // isMayhemMode read at byte 81, which only lines up if creator occupies
+  // exactly bytes 49-80 (49 + 32 = 81).
+  const creator = new PublicKey(data.subarray(49, 81));
 
   // Check for mayhem mode flag (byte 81 in extended accounts)
   let isMayhemMode = false;
@@ -213,6 +221,7 @@ export function parseBondingCurveState(data: Buffer): BondingCurveState | null {
     realSolReserves,
     tokenTotalSupply,
     complete,
+    creator,
     isMayhemMode,
   };
 }
@@ -905,6 +914,61 @@ export async function getTokenBalance(
   } catch {
     return null;
   }
+}
+
+export interface PumpTokenHolder {
+  wallet: string;
+  balance: number;
+  balanceRaw: string;
+  percentage: number;
+  isCreator: boolean;
+}
+
+/**
+ * Get top token holders directly from validator state via
+ * getTokenLargestAccounts — no dependency on pump.fun's frontend/advanced
+ * API, both of which are Cloudflare-blocked from server-side requests
+ * (confirmed live: every endpoint on both hosts returns HTTP 403 with a
+ * Cloudflare challenge page from this environment). Hard-capped by the
+ * RPC method itself at 20 results. Includes the bonding curve's own vault
+ * as a "holder" if the curve hasn't graduated yet — accurate, same as any
+ * standard Solana explorer would show, not filtered out.
+ */
+export async function getPumpTokenHolders(
+  connection: Connection,
+  mint: PublicKey | string
+): Promise<PumpTokenHolder[]> {
+  const mintPubkey = typeof mint === 'string' ? new PublicKey(mint) : mint;
+
+  const [largest, supply, curveState] = await Promise.all([
+    connection.getTokenLargestAccounts(mintPubkey),
+    connection.getTokenSupply(mintPubkey),
+    getBondingCurveState(connection, mintPubkey).catch(() => null),
+  ]);
+
+  const totalSupply = Number(supply.value.amount);
+  if (totalSupply === 0 || largest.value.length === 0) return [];
+
+  const accountInfos = await connection.getMultipleAccountsInfo(largest.value.map((a) => a.address));
+  const creatorBase58 = curveState?.creator.toBase58();
+
+  return largest.value.map((account, i) => {
+    // SPL Token / Token-2022 account layout: mint (32) + owner (32) +
+    // amount (8, u64 LE) + ... — both programs share this prefix.
+    const data = accountInfos[i]?.data;
+    const owner = data && data.length >= 64
+      ? new PublicKey(data.subarray(32, 64)).toBase58()
+      : account.address.toBase58();
+    const balanceRaw = account.amount;
+
+    return {
+      wallet: owner,
+      balance: Number(balanceRaw) / (10 ** TOKEN_DECIMALS),
+      balanceRaw,
+      percentage: (Number(balanceRaw) / totalSupply) * 100,
+      isCreator: owner === creatorBase58,
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Continues the pump.fun/PumpSwap edge-case audit. Confirmed live: both `frontend-api-v3.pump.fun` and `advanced-api-v2.pump.fun` return HTTP 403 Cloudflare blocks for every endpoint tried, from this environment — the same root cause as `isGraduated()`'s earlier fix. **This is a partial slice of that broader gap** covering the parts with a real fix available; the ~19 discovery/listing commands sharing `pumpFrontendRequest()` with no feasible on-chain replacement (trending, gainers, search, chart/OHLCV, etc. — all inherently need an off-chain indexer) are unchanged beyond inheriting a more honest error message.

- **Added `getPumpTokenHolders()` to `pumpapi.ts`** — real on-chain holder lookup via `connection.getTokenLargestAccounts()` + raw SPL account byte parsing (matches this file's existing convention, e.g. `getTokenBalance`), replacing `/pump holders`' dependency on `advanced-api-v2.pump.fun`. Also added `creator: PublicKey` extraction to `parseBondingCurveState`/`BondingCurveState` (byte 49, 32 bytes — verified against the official SDK's real `BondingCurve` type, and against this parser's own pre-existing `isMayhemMode` read at byte 81, which only lines up if `creator` occupies exactly bytes 49-80), needed for the new `isCreator` flag on holder results. `handleHolders()` now wired to this instead of the blocked API.

- **`handleSolPrice()`** now uses `getSOLPrice()` from `src/feeds/crypto/index.ts` (Binance-backed, already used elsewhere in this codebase, not Cloudflare-gated) instead of pump.fun's own `/sol-price` endpoint.

- **`pumpFrontendRequest()`'s error message** now distinguishes a genuine Cloudflare block (403 status + non-JSON content-type — live-verified this returns `text/html`) from other failures, so a real 404 for an unknown mint still reports as a 404 instead of being mislabeled. For the commands with no on-chain alternative, this at least makes the failure honest and actionable ("pump.fun's data API is blocking this request... not fixable per-request") instead of a bare, confusing status code.

Also checked and found already-safe: `handleBalance`/`handleHoldings` already wrap their frontend-API enrichment calls in `.catch(() => null)` and degrade gracefully — their core data comes from `pumpapi.getTokenBalance`/`getUserPumpTokens`, both already on-chain.

## Test plan

- `npm run typecheck` — clean
- `npm run test` — 172/172 passing
- Live-verified against real mainnet (scratch scripts deleted, not part of this diff):
  - Real holder data pulled for a known mint via `getTokenLargestAccounts`.
  - `getSOLPrice()` returns a plausible USD figure.
  - Confirmed the Cloudflare block returns `content-type: text/html` on a 403, matching the new detection logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)