### PR TITLE
fix: load Discord credentials from environment

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -420,6 +420,21 @@ export async function loadConfig(customPath?: string): Promise<Config> {
   // Substitute environment variables
   const config = substituteEnvVars(merged) as Config;
 
+  // Apply Discord credentials from the same environment used by the CLI entrypoint.
+  // Preserve file-provided channel settings while allowing env-only setup.
+  if (process.env.DISCORD_BOT_TOKEN || process.env.DISCORD_APP_ID) {
+    const discord = config.channels?.discord as Partial<NonNullable<Config['channels']['discord']>> | undefined;
+    const token = process.env.DISCORD_BOT_TOKEN || discord?.token || '';
+    const appId = process.env.DISCORD_APP_ID || discord?.appId;
+    config.channels = config.channels || {};
+    config.channels.discord = {
+      ...(discord || {}),
+      enabled: discord?.enabled ?? Boolean(token),
+      token,
+      ...(appId ? { appId } : {}),
+    };
+  }
+
   // Apply trading feature env overrides
   const envBool = (v: string | undefined) => v === '1' || v?.toLowerCase() === 'true';
   if (process.env.MARKET_MAKING_ENABLED) {

--- a/tests/unit/bot-manager.test.ts
+++ b/tests/unit/bot-manager.test.ts
@@ -349,6 +349,29 @@ describe('Trading Adapters', () => {
 // ============================================================================
 
 describe('Config env var overrides', () => {
+  it('maps Discord credentials into the runtime channel config', async () => {
+    const previousToken = process.env.DISCORD_BOT_TOKEN;
+    const previousAppId = process.env.DISCORD_APP_ID;
+    process.env.DISCORD_BOT_TOKEN = 'test-discord-token';
+    process.env.DISCORD_APP_ID = 'test-discord-app-id';
+
+    try {
+      const { loadConfig } = await import('../../src/utils/config.js');
+      const config = await loadConfig('/dev/null');
+
+      assert.deepEqual(config.channels?.discord, {
+        enabled: true,
+        token: 'test-discord-token',
+        appId: 'test-discord-app-id',
+      });
+    } finally {
+      if (previousToken === undefined) delete process.env.DISCORD_BOT_TOKEN;
+      else process.env.DISCORD_BOT_TOKEN = previousToken;
+      if (previousAppId === undefined) delete process.env.DISCORD_APP_ID;
+      else process.env.DISCORD_APP_ID = previousAppId;
+    }
+  });
+
   it('MARKET_MAKING_ENABLED sets config.trading.marketMaking.enabled', async () => {
     // Save and set env
     const prev = process.env.MARKET_MAKING_ENABLED;


### PR DESCRIPTION
The CLI and gateway load configuration through `src/utils/config.ts`, but that loader did not map `DISCORD_BOT_TOKEN` or `DISCORD_APP_ID`. The separate config implementation already supported those variables, so a configured Discord channel could be silently skipped at runtime.

This patch applies both variables to the runtime channel config, preserves file-provided settings, supports env-only token setup, and adds a regression test. It addresses the Discord portion of #107; the retired Anthropic model portion is handled separately by #106/#108, so this PR intentionally does not close the bundled issue.

Validation: `npm run typecheck`, focused bot/config tests (24 passed), `npm run build`, and `git diff --check`.
