### PR TITLE
fix: refresh project metadata and harden container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Clodds will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Updated supported-version, dependency-audit, Node.js, and bundled-skill documentation to match the current release.
+- The Docker runtime now runs as the unprivileged `node` user and keeps writable state under `/data`.
+
+## [1.9.0] - 2026-08-31
+
+### Fixed
+- Replaced broken or deprecated integrations across Pump.fun, PumpSwap, Meteora DBC, Kalshi, Polymarket, Lighter, and Robinhood/Pons.
+- Corrected Solana transaction confirmation so reverted transactions are not reported as successful.
+
+### Changed
+- Improved hot-path performance for market scans, deduplication, and Lighter nonce handling.
+- Completed a live-verification audit of supported trading venues.
+
 ## [1.2.1] - 2026-02-09
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM node:22-bookworm-slim AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV HOME=/data
 ENV CLODDS_STATE_DIR=/data
 ENV CLODDS_WORKSPACE=/data/workspace
 
@@ -21,7 +22,10 @@ RUN npm ci --omit=dev --legacy-peer-deps
 
 COPY --from=builder /app/dist ./dist
 
-RUN mkdir -p /data /data/workspace .transformers-cache
+RUN mkdir -p /data /data/workspace .transformers-cache \
+  && chown -R node:node /data /app/.transformers-cache
+
+USER node
 
 # Pre-download embedding model so it's warm at runtime (no first-request hang)
 RUN node -e "const{pipeline,env}=require('@xenova/transformers');env.cacheDir='./.transformers-cache';pipeline('feature-extraction','Xenova/all-MiniLM-L6-v2',{quantized:true}).then(()=>console.log('Model cached')).catch(e=>console.error('Model cache failed:',e))"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node.js">
   <img src="https://img.shields.io/badge/typescript-5.3-blue" alt="TypeScript">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/skills-119%2B-purple" alt="119+ Skills">
+  <img src="https://img.shields.io/badge/skills-121%2B-purple" alt="121+ Skills">
   <img src="https://img.shields.io/badge/markets-1000%2B-orange" alt="1000+ Markets">
   <img src="https://img.shields.io/badge/Colosseum-Agent%20Hackathon-blueviolet" alt="Built for Colosseum Hackathon">
   <img src="https://img.shields.io/badge/clones%2F14d-10.7k-brightgreen" alt="10.7k clones in 14 days">
@@ -50,6 +50,8 @@ Powered by Claude with 118+ trading strategies, whale tracking, arbitrage detect
 ---
 
 ## Quick Start
+
+> **Requirement:** Node.js 22 or newer. Node.js 20 is not supported and dependency installation may fail.
 
 ```bash
 npm install -g clodds --loglevel=error
@@ -147,12 +149,12 @@ See [docs/USER_GUIDE.md](./docs/USER_GUIDE.md) for all commands.
 | **Trading Strategies** | 118+ strategies including momentum, mean reversion, penny clipper, expiry fade, DCA bots, smart routing, whale tracking, copy trading |
 | **Risk Management** | Unified risk engine with circuit breaker, VaR/CVaR, volatility regime detection, stress testing, Kelly sizing, daily loss limits, kill switch |
 | **Backtesting** | Configurable strategy backtesting with historical data, SL/TP validation, P&L analysis |
-| **Skills System** | 119 bundled skills + lazy-loaded extensions (no missing dependencies crash) — chat-driven automation |
+| **Skills System** | 121 bundled skills + lazy-loaded extensions (no missing dependencies crash) — chat-driven automation |
 | **Token Security** | GoPlus-powered audits — honeypot detection, rug-pull analysis, holder concentration, risk scoring |
 | **Security Shield** | Code scanning (75 rules), scam DB (70+ addresses), multi-chain address checking, pre-trade tx validation |
 | **Trading** | Order execution on 16+ platforms (prediction markets, futures, Solana DEXs, EVM DEXs), portfolio tracking, P&L, DCA |
 | **Market Data** | Real-time orderbooks, candles, liquidity tracking, depth analysis, price feeds across all platforms |
-| **MCP Server** | Expose all 119 skills as MCP tools for Claude Desktop and Claude Code |
+| **MCP Server** | Expose all 121 skills as MCP tools for Claude Desktop and Claude Code |
 | **Arbitrage** | Cross-platform detection, combinatorial analysis, semantic matching, real-time scanning |
 | **AI** | 8 LLM providers, 4 specialized agents, semantic memory, 18 tools |
 | **Data Persistence** | SQLite (local), LanceDB (semantic memory + embeddings), PostgreSQL (analytics) — unlimited WebChat history, trade database, context compacting, hybrid search, user profiles |
@@ -370,7 +372,7 @@ Enable: `clodds config set ledger.enabled true`
 ┌──────────────────────────────────────────┴─────────────────────────────────────┐
 │                            AI AGENTS LAYER (4)                                 │
 │  Main (Claude) • Trading (Exec) • Research (Data) • Alerts (Monitor)          │
-│  119+ Skills • 18 Tools • LanceDB Memory • Semantic Reasoning                  │
+│  121+ Skills • 18 Tools • LanceDB Memory • Semantic Reasoning                  │
 └──────────────────────────────────────────┬─────────────────────────────────────┘
                                            │
 ┌──────────────────────────────────────────┴─────────────────────────────────────┐
@@ -622,7 +624,7 @@ docker compose up --build
 | Prediction Markets | **10** |
 | Futures Exchanges | **7** |
 | AI Tools | **18** |
-| Skills | **119** |
+| Skills | **121** |
 | LLM Providers | **8** |
 | Solana DeFi Protocols | **9** |
 | Trading Strategies | **4** |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 1.9.x   | :white_check_mark: |
+| < 1.9   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -87,15 +88,9 @@ See `/verify` command and `src/identity/erc8004.ts` for implementation.
 
 ### npm Dependencies
 
-All npm vulnerabilities have been fixed using npm overrides:
-- **bigint-buffer** → @vekexasia/bigint-buffer2 (secure fork)
-- **elliptic** → Replaced with @noble/secp256k1 (modern, audited)
-- **axios** → Forced to ^1.7.4
-- **undici** → Forced to ^6.23.0
-- **nanoid** → Forced to ^3.3.8
-- **@cosmjs/**** → Forced to ^0.38.1 (uses @noble/curves)
+Clodds uses dependency overrides and direct upgrades where a compatible fix is available. The raw `npm audit` report still includes reviewed transitive advisories in the Solana and crypto SDK dependency trees; it is not currently a zero-vulnerability report.
 
-Run `npm audit` to verify: **0 vulnerabilities**
+CI runs `audit-ci` against production dependencies and fails on any new, unreviewed advisory of moderate severity or higher. The temporary exceptions, affected dependency paths, and rationale are documented in [`audit-ci.jsonc`](./audit-ci.jsonc). Revisit those exceptions as upstream SDKs release compatible fixes.
 
 ### Sandbox & Dynamic Code Execution
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -343,7 +343,7 @@ Loaded by `src/skills/loader.ts`. These are markdown files injected into the AI'
 - Lives in: `src/skills/bundled/<name>/SKILL.md`
 - Format: YAML frontmatter + markdown body
 - Loaded by: `SkillManager`
-- 119 skills defined this way
+- 121 skills defined this way
 
 ### 2. TypeScript Handlers (Executor Skills)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -178,7 +178,7 @@ clodds mcp install              # Auto-configure Claude Desktop & Claude Code
 clodds mcp uninstall            # Remove Clodds from Claude config
 ```
 
-Exposes all 119 skills as MCP tools. After `clodds mcp install`, restart Claude Desktop/Code to use Clodds skills directly from Claude.
+Exposes all 121 skills as MCP tools. After `clodds mcp install`, restart Claude Desktop/Code to use Clodds skills directly from Claude.
 
 ### QMD (Quantitative Market Data) Commands
 

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -3750,7 +3750,7 @@ export function createOnboardCommand(program: Command): void {
       }
       console.log('');
       console.log(`  ${bold('AI Trading Terminal')} ${dim('for prediction markets, crypto & futures')}`);
-      console.log(`  ${dim('10 markets  \u00b7  21 channels  \u00b7  119 skills')}`);
+      console.log(`  ${dim('10 markets  \u00b7  21 channels  \u00b7  121 skills')}`);
       console.log('');
       console.log(`  ${dim('='.repeat(56))}`);
       console.log('');

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,7 +4,7 @@
  * Features:
  * - JSON5 config file loading
  * - Environment variable substitution
- * - Config validation with Zod
+ * - Handwritten config validation
  * - Default values
  * - Config paths resolution
  * - Backup rotation

--- a/src/skills/help.ts
+++ b/src/skills/help.ts
@@ -1,7 +1,7 @@
 /**
  * Standardized Help System for Skills
  *
- * Provides consistent help output format across all 119 skills.
+ * Provides consistent help output format across all 121 skills.
  * Skills call formatHelp() in their default/help case.
  */
 


### PR DESCRIPTION
Closes #117

## What changed
- document Node.js 22+ and update bundled skill references to the verified count of 121
- bring SECURITY.md and CHANGELOG.md in line with the current 1.9 release and reviewed audit policy
- describe the actual handwritten config validation
- run the production container as the unprivileged node user with writable state under /data

The README references to 118+ are intentionally retained where they describe trading strategies, not bundled skills.

## Verification
- npm run build
- git diff --check
- filesystem assertion: 121 bundled skill directories
- Dockerfile structural check (Docker is not installed in the local verification environment)