### PR TITLE
fix: enforce safety gates across futures and swaps

### DIFF
--- a/src/agents/handlers/binance.ts
+++ b/src/agents/handlers/binance.ts
@@ -9,6 +9,7 @@ import type { ToolInput, HandlerResult, HandlersMap, HandlerContext } from './ty
 import { errorResult, successResult } from './types';
 import type { BinanceFuturesConfig } from '../../exchanges/binance-futures';
 import * as binanceFutures from '../../exchanges/binance-futures';
+import { guardTrade } from './trading-guard';
 
 // =============================================================================
 // HELPERS
@@ -116,6 +117,11 @@ async function longHandler(
   const leverage = toolInput.leverage as number | undefined;
   try {
     const config: BinanceFuturesConfig = { ...env.config, dryRun: env.dryRun };
+    const unavailable = guardTrade(context, `Binance ${symbol} futures long`, undefined, { skipSizeLimit: true });
+    if (unavailable) return unavailable;
+    const price = await binanceFutures.getPrice(config, symbol);
+    const blocked = guardTrade(context, `Binance ${symbol} futures long`, quantity * price, { requireNotional: true });
+    if (blocked) return blocked;
     const result = await binanceFutures.openLong(config, symbol, quantity, leverage);
     // Log trade to database
     context.db.logBinanceFuturesTrade({
@@ -146,6 +152,11 @@ async function shortHandler(
   const leverage = toolInput.leverage as number | undefined;
   try {
     const config: BinanceFuturesConfig = { ...env.config, dryRun: env.dryRun };
+    const unavailable = guardTrade(context, `Binance ${symbol} futures short`, undefined, { skipSizeLimit: true });
+    if (unavailable) return unavailable;
+    const price = await binanceFutures.getPrice(config, symbol);
+    const blocked = guardTrade(context, `Binance ${symbol} futures short`, quantity * price, { requireNotional: true });
+    if (blocked) return blocked;
     const result = await binanceFutures.openShort(config, symbol, quantity, leverage);
     // Log trade to database
     context.db.logBinanceFuturesTrade({
@@ -174,6 +185,8 @@ async function closeHandler(
   const symbol = toolInput.symbol as string;
   try {
     const config: BinanceFuturesConfig = { ...env.config, dryRun: env.dryRun };
+    const blocked = guardTrade(context, `Binance ${symbol} futures close`, undefined, { skipSizeLimit: true });
+    if (blocked) return blocked;
     const result = await binanceFutures.closePosition(config, symbol);
     if (!result) {
       return JSON.stringify({ error: `No open position for ${symbol}` });

--- a/src/agents/handlers/bybit.ts
+++ b/src/agents/handlers/bybit.ts
@@ -9,6 +9,7 @@ import type { ToolInput, HandlerResult, HandlersMap, HandlerContext } from './ty
 import { errorResult } from './types';
 import type { BybitConfig } from '../../exchanges/bybit';
 import * as bybit from '../../exchanges/bybit';
+import { guardTrade } from './trading-guard';
 
 // =============================================================================
 // HELPERS
@@ -116,6 +117,11 @@ async function longHandler(
   const leverage = toolInput.leverage as number | undefined;
   try {
     const config: BybitConfig = { ...env.config, dryRun: env.dryRun };
+    const unavailable = guardTrade(context, `Bybit ${symbol} futures long`, undefined, { skipSizeLimit: true });
+    if (unavailable) return unavailable;
+    const price = await bybit.getPrice(config, symbol);
+    const blocked = guardTrade(context, `Bybit ${symbol} futures long`, qty * price, { requireNotional: true });
+    if (blocked) return blocked;
     const result = await bybit.openLong(config, symbol, qty, leverage);
     // Log trade to database
     context.db.logBybitFuturesTrade({
@@ -146,6 +152,11 @@ async function shortHandler(
   const leverage = toolInput.leverage as number | undefined;
   try {
     const config: BybitConfig = { ...env.config, dryRun: env.dryRun };
+    const unavailable = guardTrade(context, `Bybit ${symbol} futures short`, undefined, { skipSizeLimit: true });
+    if (unavailable) return unavailable;
+    const price = await bybit.getPrice(config, symbol);
+    const blocked = guardTrade(context, `Bybit ${symbol} futures short`, qty * price, { requireNotional: true });
+    if (blocked) return blocked;
     const result = await bybit.openShort(config, symbol, qty, leverage);
     // Log trade to database
     context.db.logBybitFuturesTrade({
@@ -174,6 +185,8 @@ async function closeHandler(
   const symbol = toolInput.symbol as string;
   try {
     const config: BybitConfig = { ...env.config, dryRun: env.dryRun };
+    const blocked = guardTrade(context, `Bybit ${symbol} futures close`, undefined, { skipSizeLimit: true });
+    if (blocked) return blocked;
     const result = await bybit.closePosition(config, symbol);
     if (!result) {
       return JSON.stringify({ error: `No open position for ${symbol}` });

--- a/src/agents/handlers/hyperliquid.ts
+++ b/src/agents/handlers/hyperliquid.ts
@@ -9,6 +9,7 @@ import type { ToolInput, HandlerResult, HandlersMap, HandlerContext } from './ty
 import { errorResult } from './types';
 import type { HyperliquidConfig } from '../../exchanges/hyperliquid';
 import * as hyperliquid from '../../exchanges/hyperliquid';
+import { guardTrade } from './trading-guard';
 
 // =============================================================================
 // HELPERS
@@ -154,6 +155,12 @@ async function longHandler(
   const size = toolInput.size as number;
   const leverage = toolInput.leverage as number | undefined;
   try {
+    const unavailable = guardTrade(context, `Hyperliquid ${coin} futures long`, undefined, { skipSizeLimit: true });
+    if (unavailable) return unavailable;
+    const mids = await hyperliquid.getAllMids();
+    const price = Number(mids[coin]);
+    const blocked = guardTrade(context, `Hyperliquid ${coin} futures long`, size * price, { requireNotional: true });
+    if (blocked) return blocked;
     if (leverage) {
       await hyperliquid.updateLeverage(env.config, coin, leverage);
     }
@@ -190,6 +197,12 @@ async function shortHandler(
   const size = toolInput.size as number;
   const leverage = toolInput.leverage as number | undefined;
   try {
+    const unavailable = guardTrade(context, `Hyperliquid ${coin} futures short`, undefined, { skipSizeLimit: true });
+    if (unavailable) return unavailable;
+    const mids = await hyperliquid.getAllMids();
+    const price = Number(mids[coin]);
+    const blocked = guardTrade(context, `Hyperliquid ${coin} futures short`, size * price, { requireNotional: true });
+    if (blocked) return blocked;
     if (leverage) {
       await hyperliquid.updateLeverage(env.config, coin, leverage);
     }
@@ -224,6 +237,8 @@ async function closeHandler(
   if (!env) return errorResult('Set HYPERLIQUID_WALLET and HYPERLIQUID_PRIVATE_KEY');
   const coin = toolInput.coin as string;
   try {
+    const blocked = guardTrade(context, `Hyperliquid ${coin} futures close`, undefined, { skipSizeLimit: true });
+    if (blocked) return blocked;
     // Get current position
     const state = await hyperliquid.getUserState(env.wallet);
     const position = state.assetPositions.find(p => p.position.coin === coin);

--- a/src/agents/handlers/solana.ts
+++ b/src/agents/handlers/solana.ts
@@ -10,8 +10,9 @@
  * - Drift (perps + prediction markets)
  */
 
-import type { ToolInput, HandlerResult, HandlersMap } from './types';
+import type { ToolInput, HandlerResult, HandlersMap, HandlerContext } from './types';
 import { safeHandler } from './types';
+import { validatePreTrade } from '../../trading/pre-trade';
 
 // Lazy imports to avoid loading heavy SDKs unless needed
 const getSolanaModules = async () => {
@@ -29,6 +30,78 @@ const getSolanaModules = async () => {
   return { wallet, jupiter, raydium, orca, meteora, pumpapi, drift, pools, tokenlist };
 };
 
+const SOLANA_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const USDC_BASE_UNITS = 1_000_000;
+
+function assertSwapGate(
+  context: HandlerContext,
+  label: string,
+  notionalUsd?: number,
+  requireNotional = false
+): void {
+  const error = validatePreTrade({
+    label,
+    notionalUsd,
+    maxOrderSize: context.tradingContext?.maxOrderSize,
+    requireNotional,
+    skipSizeLimit: !requireNotional,
+  });
+  if (error) throw new Error(error);
+}
+
+type SwapQuote = { inAmount: string; outAmount: string };
+type SwapQuoteFn = (params: {
+  inputMint: string;
+  outputMint: string;
+  amount: string;
+  swapMode?: 'ExactIn' | 'ExactOut';
+  slippageBps?: number;
+}) => Promise<SwapQuote>;
+
+export async function estimateSwapNotionalUsd(
+  getQuote: SwapQuoteFn,
+  params: {
+    inputMint: string;
+    outputMint?: string;
+    amount: string;
+    exactOutput?: boolean;
+    slippageBps?: number;
+  }
+): Promise<number> {
+  let inputAmount = params.amount;
+
+  if (params.exactOutput) {
+    if (!params.outputMint) throw new Error('Output mint is required to value an exact-output swap');
+    const routeQuote = await getQuote({
+      inputMint: params.inputMint,
+      outputMint: params.outputMint,
+      amount: params.amount,
+      swapMode: 'ExactOut',
+      slippageBps: params.slippageBps,
+    });
+    inputAmount = routeQuote.inAmount;
+  }
+
+  if (params.inputMint === SOLANA_USDC_MINT) {
+    const notional = Number(inputAmount) / USDC_BASE_UNITS;
+    if (!Number.isFinite(notional) || notional <= 0) throw new Error('Invalid USDC input amount');
+    return notional;
+  }
+
+  const usdQuote = await getQuote({
+    inputMint: params.inputMint,
+    outputMint: SOLANA_USDC_MINT,
+    amount: inputAmount,
+    swapMode: 'ExactIn',
+    slippageBps: params.slippageBps,
+  });
+  const notional = Number(usdQuote.outAmount) / USDC_BASE_UNITS;
+  if (!Number.isFinite(notional) || notional <= 0) {
+    throw new Error(`Could not determine USD value for input mint ${params.inputMint}`);
+  }
+  return notional;
+}
+
 // ============================================================================
 // Wallet / Address
 // ============================================================================
@@ -45,7 +118,7 @@ async function addressHandler(): Promise<HandlerResult> {
 // Jupiter Handlers
 // ============================================================================
 
-async function jupiterSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
+async function jupiterSwapHandler(toolInput: ToolInput, context: HandlerContext): Promise<HandlerResult> {
   const inputMint = toolInput.input_mint as string;
   const outputMint = toolInput.output_mint as string;
   const amount = toolInput.amount as string;
@@ -56,6 +129,15 @@ async function jupiterSwapHandler(toolInput: ToolInput): Promise<HandlerResult> 
 
   return safeHandler(async () => {
     const { wallet, jupiter } = await getSolanaModules();
+    assertSwapGate(context, 'Jupiter swap');
+    const notionalUsd = await estimateSwapNotionalUsd(jupiter.getJupiterQuote, {
+      inputMint,
+      outputMint,
+      amount,
+      exactOutput: swapMode === 'ExactOut',
+      slippageBps,
+    });
+    assertSwapGate(context, 'Jupiter swap', notionalUsd, true);
     const keypair = wallet.loadSolanaKeypair();
     const connection = wallet.getSolanaConnection();
     return jupiter.executeJupiterSwap(connection, keypair, {
@@ -74,17 +156,30 @@ async function jupiterSwapHandler(toolInput: ToolInput): Promise<HandlerResult> 
 // Raydium Handlers
 // ============================================================================
 
-async function raydiumSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
+async function raydiumSwapHandler(toolInput: ToolInput, context: HandlerContext): Promise<HandlerResult> {
   return safeHandler(async () => {
-    const { wallet, raydium } = await getSolanaModules();
+    const { wallet, raydium, jupiter } = await getSolanaModules();
+    const inputMint = toolInput.input_mint as string;
+    const outputMint = toolInput.output_mint as string;
+    const amount = toolInput.amount as string;
+    const swapMode = toolInput.swap_mode as 'BaseIn' | 'BaseOut' | undefined;
+    assertSwapGate(context, 'Raydium swap');
+    const notionalUsd = await estimateSwapNotionalUsd(jupiter.getJupiterQuote, {
+      inputMint,
+      outputMint,
+      amount,
+      exactOutput: swapMode === 'BaseOut',
+      slippageBps: toolInput.slippage_bps as number | undefined,
+    });
+    assertSwapGate(context, 'Raydium swap', notionalUsd, true);
     const keypair = wallet.loadSolanaKeypair();
     const connection = wallet.getSolanaConnection();
     return raydium.executeRaydiumSwap(connection, keypair, {
-      inputMint: toolInput.input_mint as string,
-      outputMint: toolInput.output_mint as string,
-      amount: toolInput.amount as string,
+      inputMint,
+      outputMint,
+      amount,
       slippageBps: toolInput.slippage_bps as number | undefined,
-      swapMode: toolInput.swap_mode as 'BaseIn' | 'BaseOut' | undefined,
+      swapMode,
       txVersion: toolInput.tx_version as 'V0' | 'LEGACY' | undefined,
       computeUnitPriceMicroLamports: toolInput.compute_unit_price_micro_lamports as number | undefined,
     });
@@ -123,15 +218,24 @@ async function raydiumQuoteHandler(toolInput: ToolInput): Promise<HandlerResult>
 // Orca Handlers
 // ============================================================================
 
-async function orcaSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
+async function orcaSwapHandler(toolInput: ToolInput, context: HandlerContext): Promise<HandlerResult> {
   return safeHandler(async () => {
-    const { wallet, orca } = await getSolanaModules();
+    const { wallet, orca, jupiter } = await getSolanaModules();
+    const inputMint = toolInput.input_mint as string;
+    const amount = toolInput.amount as string;
+    assertSwapGate(context, 'Orca swap');
+    const notionalUsd = await estimateSwapNotionalUsd(jupiter.getJupiterQuote, {
+      inputMint,
+      amount,
+      slippageBps: toolInput.slippage_bps as number | undefined,
+    });
+    assertSwapGate(context, 'Orca swap', notionalUsd, true);
     const keypair = wallet.loadSolanaKeypair();
     const connection = wallet.getSolanaConnection();
     return orca.executeOrcaWhirlpoolSwap(connection, keypair, {
       poolAddress: toolInput.pool_address as string,
-      inputMint: toolInput.input_mint as string,
-      amount: toolInput.amount as string,
+      inputMint,
+      amount,
       slippageBps: toolInput.slippage_bps as number | undefined,
     });
   });
@@ -168,16 +272,25 @@ async function orcaQuoteHandler(toolInput: ToolInput): Promise<HandlerResult> {
 // Meteora Handlers
 // ============================================================================
 
-async function meteoraSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
+async function meteoraSwapHandler(toolInput: ToolInput, context: HandlerContext): Promise<HandlerResult> {
   return safeHandler(async () => {
-    const { wallet, meteora } = await getSolanaModules();
+    const { wallet, meteora, jupiter } = await getSolanaModules();
+    const inputMint = toolInput.input_mint as string;
+    const amount = toolInput.in_amount as string;
+    assertSwapGate(context, 'Meteora swap');
+    const notionalUsd = await estimateSwapNotionalUsd(jupiter.getJupiterQuote, {
+      inputMint,
+      amount,
+      slippageBps: toolInput.slippage_bps as number | undefined,
+    });
+    assertSwapGate(context, 'Meteora swap', notionalUsd, true);
     const keypair = wallet.loadSolanaKeypair();
     const connection = wallet.getSolanaConnection();
     return meteora.executeMeteoraDlmmSwap(connection, keypair, {
       poolAddress: toolInput.pool_address as string,
-      inputMint: toolInput.input_mint as string,
+      inputMint,
       outputMint: toolInput.output_mint as string,
-      inAmount: toolInput.in_amount as string,
+      inAmount: amount,
       slippageBps: toolInput.slippage_bps as number | undefined,
       allowPartialFill: toolInput.allow_partial_fill as boolean | undefined,
       maxExtraBinArrays: toolInput.max_extra_bin_arrays as number | undefined,
@@ -1126,7 +1239,7 @@ async function autoRouteHandler(toolInput: ToolInput): Promise<HandlerResult> {
   });
 }
 
-async function autoSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
+async function autoSwapHandler(toolInput: ToolInput, context: HandlerContext): Promise<HandlerResult> {
   const amount = toolInput.amount as string;
   const slippageBps = toolInput.slippage_bps as number | undefined;
   const sortBy = toolInput.sort_by as 'liquidity' | 'volume24h' | undefined;
@@ -1136,9 +1249,8 @@ async function autoSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
   const tokenSymbols = toolInput.token_symbols as string[] | undefined;
 
   return safeHandler(async () => {
-    const { wallet, pools, tokenlist, meteora, raydium, orca } = await getSolanaModules();
+    const { wallet, pools, tokenlist, meteora, raydium, orca, jupiter } = await getSolanaModules();
     const connection = wallet.getSolanaConnection();
-    const keypair = wallet.loadSolanaKeypair();
 
     const resolvedMints = inputMint && outputMint
       ? [inputMint, outputMint]
@@ -1149,6 +1261,16 @@ async function autoSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
     if (resolvedMints.length < 2) {
       return { error: 'Provide input_mint/output_mint or token_symbols with 2 entries.' };
     }
+
+    assertSwapGate(context, 'automatic Solana swap');
+    const notionalUsd = await estimateSwapNotionalUsd(jupiter.getJupiterQuote, {
+      inputMint: resolvedMints[0],
+      outputMint: resolvedMints[1],
+      amount,
+      slippageBps,
+    });
+    assertSwapGate(context, 'automatic Solana swap', notionalUsd, true);
+    const keypair = wallet.loadSolanaKeypair();
 
     const { pool } = await pools.selectBestPoolWithResolvedMints(connection, {
       tokenMints: resolvedMints,
@@ -1309,13 +1431,16 @@ async function bagsQuoteHandler(toolInput: ToolInput): Promise<HandlerResult> {
   });
 }
 
-async function bagsSwapHandler(toolInput: ToolInput): Promise<HandlerResult> {
+async function bagsSwapHandler(toolInput: ToolInput, context: HandlerContext): Promise<HandlerResult> {
   const inputMint = toolInput.input_mint as string;
   const outputMint = toolInput.output_mint as string;
   const amount = toolInput.amount as string;
 
   return safeHandler(async () => {
-    const { wallet } = await getSolanaModules();
+    const { wallet, jupiter } = await getSolanaModules();
+    assertSwapGate(context, 'Bags swap');
+    const notionalUsd = await estimateSwapNotionalUsd(jupiter.getJupiterQuote, { inputMint, outputMint, amount });
+    assertSwapGate(context, 'Bags swap', notionalUsd, true);
     const keypair = wallet.loadSolanaKeypair();
     const walletAddress = keypair.publicKey.toBase58();
     const connection = wallet.getSolanaConnection();

--- a/src/agents/handlers/trading-guard.ts
+++ b/src/agents/handlers/trading-guard.ts
@@ -1,0 +1,20 @@
+import type { HandlerContext, HandlerResult } from './types';
+import { errorResult } from './types';
+import { validatePreTrade } from '../../trading/pre-trade';
+
+export function guardTrade(
+  context: HandlerContext,
+  label: string,
+  notionalUsd?: number,
+  options: { requireNotional?: boolean; skipSizeLimit?: boolean } = {}
+): HandlerResult | null {
+  const error = validatePreTrade({
+    label,
+    notionalUsd,
+    maxOrderSize: context.tradingContext?.maxOrderSize,
+    requireNotional: options.requireNotional,
+    skipSizeLimit: options.skipSizeLimit,
+  });
+  return error ? errorResult(error) : null;
+}
+

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -70,7 +70,6 @@ import {
   getBestPool,
 } from '../solana/pumpapi';
 import {
-  executeJupiterSwap,
   getJupiterQuote,
   createJupiterLimitOrder,
   cancelJupiterLimitOrder,
@@ -95,7 +94,6 @@ import {
 } from '../solana/jupiter';
 import { getSolanaConnection, loadSolanaKeypair } from '../solana/wallet';
 import {
-  executeMeteoraDlmmSwap,
   executeMeteoraDlmmSwapExactOut,
   executeMeteoraDlmmSwapWithPriceImpact,
   getMeteoraDlmmQuoteExactOut,
@@ -118,7 +116,6 @@ import {
   createCustomizableMeteoraDlmmPool,
 } from '../solana/meteora';
 import {
-  executeRaydiumSwap,
   getRaydiumQuote,
   getClmmPositions,
   createClmmPosition,
@@ -133,7 +130,6 @@ import {
   getClmmConfigs,
 } from '../solana/raydium';
 import {
-  executeOrcaWhirlpoolSwap,
   getOrcaWhirlpoolQuote,
   openOrcaFullRangePosition,
   openOrcaConcentratedPosition,
@@ -152,12 +148,13 @@ import { executeDriftDirectOrder } from '../solana/drift';
 import { listMeteoraDlmmPools } from '../solana/meteora';
 import { listRaydiumPools } from '../solana/raydium';
 import { listOrcaWhirlpoolPools } from '../solana/orca';
-import { selectBestPool, selectBestPoolWithResolvedMints } from '../solana/pools';
+import { selectBestPool } from '../solana/pools';
 import { getMeteoraDlmmQuote } from '../solana/meteora';
 import { wormholeQuote, wormholeBridge, wormholeRedeem, usdcBridgeAuto, usdcQuoteAuto } from '../bridge/wormhole';
 import { isRetryableError, withRetry, RETRY_POLICIES } from '../infra/retry';
 import { createMarketIndexService, MarketIndexService } from '../market-index';
 import { enforceExposureLimits, enforceMaxOrderSize } from '../trading/risk';
+import { validatePreTrade } from '../trading/pre-trade';
 // binanceFutures — migrated to handlers/binance.ts
 // bybit — migrated to handlers/bybit.ts
 import * as mexc from '../exchanges/mexc';
@@ -13661,6 +13658,19 @@ async function executeTool(
         const leverage = toolInput.leverage as number | undefined;
         try {
           const config: mexc.MexcConfig = { apiKey, apiSecret, dryRun: process.env.DRY_RUN === 'true' };
+          const availabilityError = validatePreTrade({ label: `MEXC ${symbol} futures long`, skipSizeLimit: true });
+          if (availabilityError) return JSON.stringify({ error: availabilityError });
+          const [price, contractSize] = await Promise.all([
+            mexc.getPrice(config, symbol),
+            mexc.getContractSize(config, symbol),
+          ]);
+          const gateError = validatePreTrade({
+            label: `MEXC ${symbol} futures long`,
+            notionalUsd: vol * contractSize * price,
+            maxOrderSize: context.tradingContext?.maxOrderSize,
+            requireNotional: true,
+          });
+          if (gateError) return JSON.stringify({ error: gateError });
           const result = await mexc.openLong(config, symbol, vol, leverage);
           // Log trade to database (side: 1=Open Long)
           db.logMexcFuturesTrade({
@@ -13690,6 +13700,19 @@ async function executeTool(
         const leverage = toolInput.leverage as number | undefined;
         try {
           const config: mexc.MexcConfig = { apiKey, apiSecret, dryRun: process.env.DRY_RUN === 'true' };
+          const availabilityError = validatePreTrade({ label: `MEXC ${symbol} futures short`, skipSizeLimit: true });
+          if (availabilityError) return JSON.stringify({ error: availabilityError });
+          const [price, contractSize] = await Promise.all([
+            mexc.getPrice(config, symbol),
+            mexc.getContractSize(config, symbol),
+          ]);
+          const gateError = validatePreTrade({
+            label: `MEXC ${symbol} futures short`,
+            notionalUsd: vol * contractSize * price,
+            maxOrderSize: context.tradingContext?.maxOrderSize,
+            requireNotional: true,
+          });
+          if (gateError) return JSON.stringify({ error: gateError });
           const result = await mexc.openShort(config, symbol, vol, leverage);
           // Log trade to database (side: 3=Open Short)
           db.logMexcFuturesTrade({
@@ -13717,6 +13740,11 @@ async function executeTool(
         const symbol = toolInput.symbol as string;
         try {
           const config: mexc.MexcConfig = { apiKey, apiSecret, dryRun: process.env.DRY_RUN === 'true' };
+          const gateError = validatePreTrade({
+            label: `MEXC ${symbol} futures close`,
+            skipSizeLimit: true,
+          });
+          if (gateError) return JSON.stringify({ error: gateError });
           const result = await mexc.closePosition(config, symbol);
           if (!result) {
             return JSON.stringify({ error: `No open position for ${symbol}` });
@@ -13781,36 +13809,6 @@ async function executeTool(
           return JSON.stringify({ address: keypair.publicKey.toBase58() });
         } catch (err: unknown) {
           return JSON.stringify({ error: (err as Error).message });
-        }
-      }
-
-      case 'solana_jupiter_swap': {
-        const inputMint = toolInput.input_mint as string;
-        const outputMint = toolInput.output_mint as string;
-        const amount = toolInput.amount as string;
-        const slippageBps = toolInput.slippage_bps as number | undefined;
-        const swapMode = toolInput.swap_mode as 'ExactIn' | 'ExactOut' | undefined;
-        const priorityFeeLamports = toolInput.priority_fee_lamports as number | undefined;
-        const onlyDirectRoutes = toolInput.only_direct_routes as boolean | undefined;
-
-        try {
-          const keypair = loadSolanaKeypair();
-          const connection = getSolanaConnection();
-          const result = await executeJupiterSwap(connection, keypair, {
-            inputMint,
-            outputMint,
-            amount,
-            slippageBps,
-            swapMode,
-            priorityFeeLamports,
-            onlyDirectRoutes,
-          });
-          return JSON.stringify(result);
-        } catch (err: unknown) {
-          return JSON.stringify({
-            error: (err as Error).message,
-            hint: 'Set SOLANA_PRIVATE_KEY or SOLANA_KEYPAIR_PATH and SOLANA_RPC_URL if needed.',
-          });
         }
       }
 
@@ -14218,60 +14216,6 @@ async function executeTool(
         try {
           const connection = getSolanaConnection();
           const result = await getBestPool(connection, toolInput.mint as string);
-          return JSON.stringify(result);
-        } catch (err: unknown) {
-          return JSON.stringify({ error: (err as Error).message });
-        }
-      }
-
-      case 'meteora_dlmm_swap': {
-        try {
-          const keypair = loadSolanaKeypair();
-          const connection = getSolanaConnection();
-          const result = await executeMeteoraDlmmSwap(connection, keypair, {
-            poolAddress: toolInput.pool_address as string,
-            inputMint: toolInput.input_mint as string,
-            outputMint: toolInput.output_mint as string,
-            inAmount: toolInput.in_amount as string,
-            slippageBps: toolInput.slippage_bps as number | undefined,
-            allowPartialFill: toolInput.allow_partial_fill as boolean | undefined,
-            maxExtraBinArrays: toolInput.max_extra_bin_arrays as number | undefined,
-          });
-          return JSON.stringify(result);
-        } catch (err: unknown) {
-          return JSON.stringify({ error: (err as Error).message });
-        }
-      }
-
-      case 'raydium_swap': {
-        try {
-          const keypair = loadSolanaKeypair();
-          const connection = getSolanaConnection();
-          const result = await executeRaydiumSwap(connection, keypair, {
-            inputMint: toolInput.input_mint as string,
-            outputMint: toolInput.output_mint as string,
-            amount: toolInput.amount as string,
-            slippageBps: toolInput.slippage_bps as number | undefined,
-            swapMode: toolInput.swap_mode as 'BaseIn' | 'BaseOut' | undefined,
-            txVersion: toolInput.tx_version as 'V0' | 'LEGACY' | undefined,
-            computeUnitPriceMicroLamports: toolInput.compute_unit_price_micro_lamports as number | undefined,
-          });
-          return JSON.stringify(result);
-        } catch (err: unknown) {
-          return JSON.stringify({ error: (err as Error).message });
-        }
-      }
-
-      case 'orca_whirlpool_swap': {
-        try {
-          const keypair = loadSolanaKeypair();
-          const connection = getSolanaConnection();
-          const result = await executeOrcaWhirlpoolSwap(connection, keypair, {
-            poolAddress: toolInput.pool_address as string,
-            inputMint: toolInput.input_mint as string,
-            amount: toolInput.amount as string,
-            slippageBps: toolInput.slippage_bps as number | undefined,
-          });
           return JSON.stringify(result);
         } catch (err: unknown) {
           return JSON.stringify({ error: (err as Error).message });
@@ -15103,77 +15047,6 @@ async function executeTool(
           });
 
           return JSON.stringify(result ?? { error: 'No matching pools found' });
-        } catch (err: unknown) {
-          return JSON.stringify({ error: (err as Error).message });
-        }
-      }
-
-      case 'solana_auto_swap': {
-        try {
-          const amount = toolInput.amount as string;
-          const slippageBps = toolInput.slippage_bps as number | undefined;
-          const sortBy = toolInput.sort_by as 'liquidity' | 'volume24h' | undefined;
-          const preferredDexes = toolInput.preferred_dexes as Array<'meteora' | 'raydium' | 'orca'> | undefined;
-
-          const inputMint = toolInput.input_mint as string | undefined;
-          const outputMint = toolInput.output_mint as string | undefined;
-          const tokenSymbols = toolInput.token_symbols as string[] | undefined;
-
-          const connection = getSolanaConnection();
-          const keypair = loadSolanaKeypair();
-
-          const resolvedMints = inputMint && outputMint
-            ? [inputMint, outputMint]
-            : tokenSymbols && tokenSymbols.length >= 2
-              ? await (await import('../solana/tokenlist')).resolveTokenMints(tokenSymbols.slice(0, 2))
-              : [];
-
-          if (resolvedMints.length < 2) {
-            return JSON.stringify({ error: 'Provide input_mint/output_mint or token_symbols with 2 entries.' });
-          }
-
-          const { pool } = await selectBestPoolWithResolvedMints(connection, {
-            tokenMints: resolvedMints,
-            sortBy,
-            preferredDexes,
-          });
-
-          if (!pool) {
-            return JSON.stringify({ error: 'No matching pools found.' });
-          }
-
-          if (pool.dex === 'meteora') {
-            const result = await executeMeteoraDlmmSwap(connection, keypair, {
-              poolAddress: pool.address,
-              inputMint: resolvedMints[0],
-              outputMint: resolvedMints[1],
-              inAmount: amount,
-              slippageBps,
-            });
-            return JSON.stringify({ dex: pool.dex, pool, result });
-          }
-
-          if (pool.dex === 'raydium') {
-            const result = await executeRaydiumSwap(connection, keypair, {
-              inputMint: resolvedMints[0],
-              outputMint: resolvedMints[1],
-              amount,
-              slippageBps,
-            });
-            return JSON.stringify({ dex: pool.dex, pool, result });
-          }
-
-          if (pool.dex === 'orca') {
-            const result = await executeOrcaWhirlpoolSwap(connection, keypair, {
-              poolAddress: pool.address,
-              inputMint: resolvedMints[0],
-              amount,
-              slippageBps,
-            });
-            return JSON.stringify({ dex: pool.dex, pool, result });
-          }
-
-          return JSON.stringify({ error: 'Unsupported pool type' });
         } catch (err: unknown) {
           return JSON.stringify({ error: (err as Error).message });
         }

--- a/src/exchanges/mexc/index.ts
+++ b/src/exchanges/mexc/index.ts
@@ -122,6 +122,21 @@ export async function getPrice(config: MexcConfig, symbol: string): Promise<numb
   return typeof data.lastPrice === 'string' ? parseFloat(data.lastPrice) : data.lastPrice;
 }
 
+/** Contract multiplier used to convert MEXC volume (contracts) to base units. */
+export async function getContractSize(config: MexcConfig, symbol: string): Promise<number> {
+  const data = await request(config, 'GET', '/api/v1/contract/detail', { symbol }) as
+    | { contractSize?: number | string }
+    | Array<{ symbol?: string; contractSize?: number | string }>;
+  const detail = Array.isArray(data)
+    ? data.find(item => item.symbol === symbol) ?? data[0]
+    : data;
+  const contractSize = Number(detail?.contractSize);
+  if (!Number.isFinite(contractSize) || contractSize <= 0) {
+    throw new Error(`Invalid MEXC contract size for ${symbol}`);
+  }
+  return contractSize;
+}
+
 export async function getFundingRate(config: MexcConfig, symbol: string): Promise<FundingRate> {
   const data = await request(config, 'GET', '/api/v1/contract/funding_rate', { symbol }) as {
     fundingRate: number;

--- a/src/execution/futures.ts
+++ b/src/execution/futures.ts
@@ -17,6 +17,7 @@ import { Wallet } from 'ethers';
 import * as bybit from '../exchanges/bybit';
 import * as mexc from '../exchanges/mexc';
 import * as hyperliquid from '../exchanges/hyperliquid';
+import { validatePreTrade } from '../trading/pre-trade';
 
 // Helper to derive wallet address from private key
 function getWalletAddress(privateKey: string): string {
@@ -1363,22 +1364,111 @@ async function setHyperliquidMarginType(
 // SERVICE FACTORY
 // =============================================================================
 
+async function getBinanceMarkPrice(
+  config: NonNullable<FuturesConfig['binance']>,
+  symbol: string
+): Promise<number> {
+  const data = await binanceFuturesRequest(config, 'GET', '/fapi/v1/premiumIndex', { symbol }) as {
+    markPrice?: string;
+  };
+  const price = Number(data.markPrice);
+  if (!Number.isFinite(price) || price <= 0) throw new Error(`No valid Binance mark price for ${symbol}`);
+  return price;
+}
+
+async function getBybitMarkPrice(
+  config: NonNullable<FuturesConfig['bybit']>,
+  symbol: string
+): Promise<number> {
+  return bybit.getPrice({
+    apiKey: config.apiKey,
+    apiSecret: config.secretKey,
+    testnet: config.testnet,
+  }, symbol);
+}
+
+async function getMexcOrderValuation(
+  config: NonNullable<FuturesConfig['mexc']>,
+  symbol: string
+): Promise<{ price: number; contractSize: number }> {
+  const mexcConfig = { apiKey: config.apiKey, apiSecret: config.secretKey };
+  const [price, contractSize] = await Promise.all([
+    mexc.getPrice(mexcConfig, symbol),
+    mexc.getContractSize(mexcConfig, symbol),
+  ]);
+  return { price, contractSize };
+}
+
 export function createFuturesExecutionService(config: FuturesConfig): FuturesExecutionService {
   const defaultLeverage = config.defaultLeverage || 10;
   const defaultMarginType = config.defaultMarginType || 'isolated';
-  const maxPositionSize = config.maxPositionSize || 10000; // $10k default
+  const maxPositionSize = config.maxPositionSize ?? 10000; // $10k default
+
+  async function resolveOrderPrice(request: FuturesOrderRequest): Promise<number> {
+    if (request.price !== undefined && Number.isFinite(request.price) && request.price > 0) {
+      return request.price;
+    }
+    if (request.stopPrice !== undefined && Number.isFinite(request.stopPrice) && request.stopPrice > 0) {
+      return request.stopPrice;
+    }
+
+    switch (request.platform) {
+      case 'binance':
+        if (!config.binance) throw new Error('Binance Futures not configured');
+        return getBinanceMarkPrice(config.binance, request.symbol);
+      case 'bybit':
+        if (!config.bybit) throw new Error('Bybit not configured');
+        return getBybitMarkPrice(config.bybit, request.symbol);
+      case 'mexc':
+        if (!config.mexc) throw new Error('MEXC not configured');
+        return (await getMexcOrderValuation(config.mexc, request.symbol)).price;
+      case 'hyperliquid': {
+        if (!config.hyperliquid) throw new Error('Hyperliquid not configured');
+        const mids = await hyperliquid.getAllMids();
+        const price = Number(mids[request.symbol]);
+        if (!Number.isFinite(price) || price <= 0) {
+          throw new Error(`No valid Hyperliquid mark price for ${request.symbol}`);
+        }
+        return price;
+      }
+    }
+  }
 
   async function executeOrder(request: FuturesOrderRequest): Promise<FuturesOrderResult> {
-    // Validate position size
-    const checkPrice = request.price || 0;
-    if (checkPrice > 0 && request.size * checkPrice > maxPositionSize) {
-      return {
-        success: false,
-        error: `Position size exceeds max $${maxPositionSize}`,
-      };
+    if (!Number.isFinite(request.size) || request.size <= 0) {
+      return { success: false, error: `Invalid futures size: ${request.size}` };
     }
-    if (checkPrice === 0) {
-      logger.warn({ size: request.size, symbol: request.symbol }, 'No price available for notional size check (market order) — skipping guard');
+
+    const label = `${request.platform} ${request.symbol} futures order`;
+    const availabilityError = validatePreTrade({ label, skipSizeLimit: true });
+    if (availabilityError) return { success: false, error: availabilityError };
+
+    if (request.reduceOnly || request.closePosition) {
+      // Risk-reducing orders still honor kill switches, but are not blocked by
+      // an exposure cap that the existing position may already exceed.
+    } else {
+      let checkPrice: number;
+      let contractSize = 1;
+      try {
+        if (request.platform === 'mexc' && config.mexc) {
+          const valuation = await getMexcOrderValuation(config.mexc, request.symbol);
+          checkPrice = request.price ?? request.stopPrice ?? valuation.price;
+          contractSize = valuation.contractSize;
+        } else {
+          checkPrice = await resolveOrderPrice(request);
+        }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return { success: false, error: `Futures pre-trade price check failed: ${detail}` };
+      }
+
+      const gateError = validatePreTrade({
+        label,
+        notionalUsd: request.size * contractSize * checkPrice,
+        maxOrderSize: maxPositionSize,
+        requireNotional: true,
+      });
+      if (gateError) return { success: false, error: gateError };
     }
 
     // Dry run
@@ -1777,4 +1867,3 @@ export function createFuturesExecutionService(config: FuturesConfig): FuturesExe
 
   return service;
 }
-

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -66,7 +66,8 @@ import { setupShutdownHandlers, onShutdown, trackError } from '../utils/producti
 import { createSignalBus, type SignalBus } from './signal-bus';
 import { createTradingOrchestrator, type TradingOrchestrator } from '../trading/orchestrator';
 import { createSafetyManager, type SafetyManager } from '../trading/safety';
-import { createCircuitBreaker } from '../execution/circuit-breaker';
+import { createCircuitBreaker, type CircuitBreaker } from '../execution/circuit-breaker';
+import { configurePreTradeGate } from '../trading/pre-trade';
 import { createTradingApiRouter } from './api-routes';
 import { createPositionManager, type PositionManager } from '../execution/position-manager';
 import { createPositionCloseCallback, createPositionBridge, type PositionBridge } from '../trading/position-bridge';
@@ -649,28 +650,35 @@ export async function createGateway(config: Config): Promise<AppGateway> {
     }
   }
 
+  // Install one process-wide gate before any lazily loaded futures or Solana
+  // execution paths can run. Prediction execution is attached below as well.
+  const circuitBreaker: CircuitBreaker = createCircuitBreaker({
+    maxLossUsd: config.trading?.maxDailyLoss ?? 1000,
+    maxConsecutiveLosses: 5,
+    maxErrorRate: 0.5,
+    resetTimeoutMs: 3600_000,
+  });
+  circuitBreaker.start();
+
+  let safetyManager: SafetyManager | null = createSafetyManager(db, {
+    dailyLossLimit: config.trading?.maxDailyLoss ?? 500,
+    maxDrawdownPct: 20,
+    maxConcentrationPct: 25,
+    maxSameDirectionPositions: 5,
+  });
+
+  configurePreTradeGate({
+    circuitBreaker,
+    safety: safetyManager,
+    maxOrderSize: () => currentConfig.trading?.maxOrderSize ?? 1000,
+  });
+
   // Wire safety + circuit breaker + orchestrator around execution service.
   // By reassigning executionService, all downstream consumers (signal router,
   // copy trading, arbitrage executor) automatically get safety-checked execution.
   let orchestrator: TradingOrchestrator | null = null;
-  let safetyManager: SafetyManager | null = null;
   if (executionService) {
-    // Circuit breaker: execution-level error rate + loss tracking
-    const circuitBreaker = createCircuitBreaker({
-      maxLossUsd: config.trading?.maxDailyLoss ?? 1000,
-      maxConsecutiveLosses: 5,
-      maxErrorRate: 0.5,
-      resetTimeoutMs: 3600_000,
-    });
     executionService.setCircuitBreaker(circuitBreaker);
-
-    // Safety manager: daily loss limits, drawdown, concentration checks
-    safetyManager = createSafetyManager(db, {
-      dailyLossLimit: config.trading?.maxDailyLoss ?? 500,
-      maxDrawdownPct: 20,
-      maxConcentrationPct: 25,
-      maxSameDirectionPositions: 5,
-    });
 
     // Orchestrator wraps execution with pre-trade safety validation
     orchestrator = createTradingOrchestrator({
@@ -2518,6 +2526,9 @@ export async function createGateway(config: Config): Promise<AppGateway> {
         if (cronService) await cronService.stop();
         if (monitoring) monitoring.stop();
         providerHealth?.stop();
+        circuitBreaker.stop();
+        safetyManager?.destroy();
+        configurePreTradeGate(null);
         await feeds.stop();
         if (channels) await channels.stop();
         await httpGateway.stop();
@@ -2823,6 +2834,10 @@ export async function createGateway(config: Config): Promise<AppGateway> {
         executionService.stop();
         executionService = null;
       }
+      circuitBreaker.stop();
+      safetyManager?.destroy();
+      safetyManager = null;
+      configurePreTradeGate(null);
 
       // Close execution queue producer
       if (executionProducer) {

--- a/src/trading/futures/index.ts
+++ b/src/trading/futures/index.ts
@@ -19,6 +19,7 @@ import * as secp from '@noble/secp256k1';
 import { keccak_256 } from '@noble/hashes/sha3';
 import { logger } from '../../utils/logger';
 import { Pool } from 'pg';
+import { validatePreTrade } from '../pre-trade';
 
 // =============================================================================
 // HELPERS
@@ -143,6 +144,8 @@ export interface FuturesMarket {
   quoteAsset: string;
   tickSize: number;
   lotSize: number;
+  /** Base-asset amount represented by one contract (derivatives venues only). */
+  contractSize?: number;
   minNotional: number;
   maxLeverage: number;
   fundingRate: number;
@@ -4211,6 +4214,7 @@ class MexcFuturesClient {
         quoteCoin: string;
         priceUnit: string;
         volUnit: string;
+        contractSize: string;
         minVol: string;
         maxLeverage: number;
       }>>,
@@ -4237,6 +4241,7 @@ class MexcFuturesClient {
           quoteAsset: c.quoteCoin,
           tickSize: parseFloat(c.priceUnit),
           lotSize: parseFloat(c.volUnit),
+          contractSize: parseFloat(c.contractSize),
           minNotional: parseFloat(c.minVol),
           maxLeverage: c.maxLeverage,
           fundingRate: parseFloat(ticker?.fundingRate || '0') * 100,
@@ -5352,9 +5357,41 @@ export class FuturesService extends EventEmitter {
   async placeOrder(exchange: FuturesExchange, order: FuturesOrderRequest): Promise<FuturesOrder> {
     const config = this.config.find(c => c.exchange === exchange);
 
+    if (!Number.isFinite(order.size) || order.size <= 0) {
+      throw new Error(`Invalid futures size: ${order.size}`);
+    }
+
     if (config?.maxLeverage && order.leverage && order.leverage > config.maxLeverage) {
       throw new Error(`Leverage ${order.leverage}x exceeds max ${config.maxLeverage}x`);
     }
+
+    const label = `${exchange} ${order.symbol} futures order`;
+    const availabilityError = validatePreTrade({ label, skipSizeLimit: true });
+    if (availabilityError) throw new Error(availabilityError);
+
+    let gateError: string | null;
+    if (order.reduceOnly) {
+      gateError = null;
+    } else {
+      let price = order.price ?? order.stopPrice;
+      let contractSize = 1;
+      if (exchange === 'mexc') {
+        const market = (await this.getMarkets(exchange)).find(item => item.symbol === order.symbol);
+        price = price ?? market?.markPrice;
+        contractSize = market?.contractSize ?? 0;
+      } else if (!Number.isFinite(price) || (price ?? 0) <= 0) {
+        const tickers = await this.getTickerPrice(exchange, order.symbol);
+        price = tickers.find(ticker => ticker.symbol === order.symbol)?.price ?? tickers[0]?.price;
+      }
+
+      gateError = validatePreTrade({
+        label,
+        notionalUsd: price !== undefined ? order.size * contractSize * price : undefined,
+        maxOrderSize: config?.maxPositionSize ?? 10000,
+        requireNotional: true,
+      });
+    }
+    if (gateError) throw new Error(gateError);
 
     const result = await this.getClient(exchange).placeOrder(order);
     this.emit('order', result);
@@ -5409,6 +5446,12 @@ export class FuturesService extends EventEmitter {
   }
 
   async closePosition(exchange: FuturesExchange, symbol: string): Promise<FuturesOrder | null> {
+    const gateError = validatePreTrade({
+      label: `${exchange} ${symbol} futures close`,
+      skipSizeLimit: true,
+    });
+    if (gateError) throw new Error(gateError);
+
     const result = await this.getClient(exchange).closePosition(symbol);
     if (result) {
       this.emit('positionClosed', result);

--- a/src/trading/pre-trade.ts
+++ b/src/trading/pre-trade.ts
@@ -1,0 +1,86 @@
+/**
+ * Process-wide pre-trade gate shared by prediction, futures, and swap paths.
+ *
+ * The gateway installs the active safety sources once. Execution modules that are
+ * loaded lazily (for example the futures skill) still consult the same gate.
+ */
+
+export interface TradeGateSource {
+  canTrade(): boolean;
+  getState?(): unknown;
+}
+
+export interface TradeGateConfig {
+  circuitBreaker?: TradeGateSource | null;
+  safety?: TradeGateSource | null;
+  maxOrderSize?: number | (() => number | undefined);
+}
+
+export interface PreTradeCheck {
+  label: string;
+  notionalUsd?: number;
+  /** Additional caller-specific cap. The strictest positive cap wins. */
+  maxOrderSize?: number;
+  /** Reject when a USD notional cannot be established. */
+  requireNotional?: boolean;
+  /** Apply breaker/kill-switch checks but allow a risk-reducing exit over the cap. */
+  skipSizeLimit?: boolean;
+}
+
+let activeGate: TradeGateConfig | null = null;
+
+export function configurePreTradeGate(config: TradeGateConfig | null): void {
+  activeGate = config;
+}
+
+function stateReason(source: TradeGateSource, fallback: string): string {
+  const state = source.getState?.();
+  if (!state || typeof state !== 'object') return fallback;
+  const record = state as Record<string, unknown>;
+  const reason = record.tripReason ?? record.disabledReason;
+  return typeof reason === 'string' && reason ? reason : fallback;
+}
+
+function checkSource(source: TradeGateSource | null | undefined, fallback: string): string | null {
+  if (!source) return null;
+  try {
+    return source.canTrade() ? null : stateReason(source, fallback);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return `${fallback}: safety check failed (${detail})`;
+  }
+}
+
+function configuredMaxOrderSize(): number | undefined {
+  const configured = activeGate?.maxOrderSize;
+  return typeof configured === 'function' ? configured() : configured;
+}
+
+export function validatePreTrade(check: PreTradeCheck): string | null {
+  const circuitError = checkSource(activeGate?.circuitBreaker, 'circuit breaker is tripped');
+  if (circuitError) return `Trading blocked for ${check.label}: ${circuitError}`;
+
+  const safetyError = checkSource(activeGate?.safety, 'trading is disabled by the safety manager');
+  if (safetyError) return `Trading blocked for ${check.label}: ${safetyError}`;
+
+  if (check.skipSizeLimit) return null;
+
+  if (check.notionalUsd !== undefined && (!Number.isFinite(check.notionalUsd) || check.notionalUsd <= 0)) {
+    return `Trading blocked for ${check.label}: invalid USD notional`;
+  }
+
+  if (check.requireNotional && check.notionalUsd === undefined) {
+    return `Trading blocked for ${check.label}: USD notional could not be determined`;
+  }
+
+  const limits = [configuredMaxOrderSize(), check.maxOrderSize]
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0);
+  const limit = limits.length > 0 ? Math.min(...limits) : undefined;
+
+  if (limit !== undefined && check.notionalUsd !== undefined && check.notionalUsd > limit) {
+    return `Trading blocked for ${check.label}: order size $${check.notionalUsd.toFixed(2)} exceeds max $${limit}`;
+  }
+
+  return null;
+}
+

--- a/tests/trading/futures-pre-trade.test.ts
+++ b/tests/trading/futures-pre-trade.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createFuturesExecutionService } from '../../src/execution/futures';
+import { FuturesService } from '../../src/trading/futures';
+import { configurePreTradeGate } from '../../src/trading/pre-trade';
+
+afterEach(() => configurePreTradeGate(null));
+
+describe('futures pre-trade enforcement', () => {
+  it('blocks the exported execution engine above maxOrderSize', async () => {
+    configurePreTradeGate({ maxOrderSize: 500 });
+    const service = createFuturesExecutionService({
+      binance: { apiKey: 'test', secretKey: 'test' },
+      dryRun: true,
+    });
+
+    const result = await service.placeLimitOrder({
+      platform: 'binance',
+      symbol: 'BTCUSDT',
+      side: 'long',
+      size: 0.01,
+      price: 60_000,
+    });
+
+    assert.equal(result.success, false);
+    assert.match(result.error ?? '', /exceeds max \$500/);
+  });
+
+  it('blocks the dynamically loaded futures engine above maxOrderSize', async () => {
+    configurePreTradeGate({ maxOrderSize: 500 });
+    const service = new FuturesService([{
+      exchange: 'binance',
+      credentials: { apiKey: 'test', apiSecret: 'test' },
+      dryRun: true,
+    }]);
+
+    await assert.rejects(
+      service.placeOrder('binance', {
+        symbol: 'BTCUSDT',
+        side: 'BUY',
+        type: 'LIMIT',
+        size: 0.01,
+        price: 60_000,
+      }),
+      /exceeds max \$500/
+    );
+  });
+
+  it('checks the breaker before attempting market-price discovery', async () => {
+    configurePreTradeGate({
+      circuitBreaker: {
+        canTrade: () => false,
+        getState: () => ({ tripReason: 'max_loss' }),
+      },
+      maxOrderSize: 500,
+    });
+    const service = createFuturesExecutionService({
+      binance: { apiKey: 'test', secretKey: 'test' },
+      dryRun: true,
+    });
+
+    const result = await service.placeMarketOrder({
+      platform: 'binance',
+      symbol: 'BTCUSDT',
+      side: 'long',
+      size: 0.001,
+    });
+
+    assert.equal(result.success, false);
+    assert.match(result.error ?? '', /max_loss/);
+  });
+
+  it('values MEXC contract volume with the venue contract multiplier', async () => {
+    configurePreTradeGate({ maxOrderSize: 500 });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      const data = url.includes('/contract/detail')
+        ? [{ symbol: 'BTC_USDT', contractSize: 0.0001 }]
+        : { lastPrice: '60000' };
+      return new Response(JSON.stringify({ code: 0, data }), { status: 200 });
+    };
+
+    try {
+      const service = createFuturesExecutionService({
+        mexc: { apiKey: 'test', secretKey: 'test' },
+        dryRun: true,
+      });
+      const result = await service.placeMarketOrder({
+        platform: 'mexc',
+        symbol: 'BTC_USDT',
+        side: 'long',
+        size: 10,
+      });
+
+      assert.equal(result.success, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/tests/trading/pre-trade.test.ts
+++ b/tests/trading/pre-trade.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { configurePreTradeGate, validatePreTrade } from '../../src/trading/pre-trade';
+
+afterEach(() => configurePreTradeGate(null));
+
+describe('shared pre-trade gate', () => {
+  it('blocks every route when the circuit breaker is tripped', () => {
+    configurePreTradeGate({
+      circuitBreaker: {
+        canTrade: () => false,
+        getState: () => ({ tripReason: 'max_loss' }),
+      },
+      maxOrderSize: 1000,
+    });
+
+    assert.match(
+      validatePreTrade({ label: 'Solana swap', notionalUsd: 10 }) ?? '',
+      /max_loss/
+    );
+  });
+
+  it('uses the strictest global and caller-specific order cap', () => {
+    configurePreTradeGate({ maxOrderSize: 1000 });
+
+    assert.match(
+      validatePreTrade({ label: 'futures order', notionalUsd: 501, maxOrderSize: 500 }) ?? '',
+      /exceeds max \$500/
+    );
+    assert.equal(
+      validatePreTrade({ label: 'futures order', notionalUsd: 500, maxOrderSize: 500 }),
+      null
+    );
+  });
+
+  it('fails closed when a route requires a missing notional', () => {
+    configurePreTradeGate({ maxOrderSize: 1000 });
+    assert.match(
+      validatePreTrade({ label: 'market order', requireNotional: true }) ?? '',
+      /could not be determined/
+    );
+  });
+
+  it('allows risk-reducing exits over the size cap but still honors kill switches', () => {
+    configurePreTradeGate({ maxOrderSize: 100 });
+    assert.equal(
+      validatePreTrade({ label: 'close position', notionalUsd: 500, skipSizeLimit: true }),
+      null
+    );
+
+    configurePreTradeGate({
+      safety: { canTrade: () => false, getState: () => ({ disabledReason: 'manual stop' }) },
+      maxOrderSize: 100,
+    });
+    assert.match(
+      validatePreTrade({ label: 'close position', notionalUsd: 500, skipSizeLimit: true }) ?? '',
+      /manual stop/
+    );
+  });
+});

--- a/tests/trading/solana-swap-safety.test.ts
+++ b/tests/trading/solana-swap-safety.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { estimateSwapNotionalUsd } from '../../src/agents/handlers/solana';
+
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+describe('Solana swap notional valuation', () => {
+  it('values USDC inputs directly from base units', async () => {
+    const quote = async () => {
+      throw new Error('quote should not be called');
+    };
+
+    const notional = await estimateSwapNotionalUsd(quote, {
+      inputMint: USDC_MINT,
+      amount: '501000000',
+    });
+
+    assert.equal(notional, 501);
+  });
+
+  it('values non-USDC inputs through a Jupiter USDC quote', async () => {
+    const quote = async () => ({ inAmount: '1000000000', outAmount: '125500000' });
+
+    const notional = await estimateSwapNotionalUsd(quote, {
+      inputMint: 'So11111111111111111111111111111111111111112',
+      amount: '1000000000',
+    });
+
+    assert.equal(notional, 125.5);
+  });
+
+  it('resolves the required input before valuing exact-output swaps', async () => {
+    const calls: Array<{ swapMode?: 'ExactIn' | 'ExactOut'; amount: string }> = [];
+    const quote = async (params: { swapMode?: 'ExactIn' | 'ExactOut'; amount: string }) => {
+      calls.push(params);
+      return params.swapMode === 'ExactOut'
+        ? { inAmount: '2000000000', outAmount: params.amount }
+        : { inAmount: params.amount, outAmount: '250000000' };
+    };
+
+    const notional = await estimateSwapNotionalUsd(quote, {
+      inputMint: 'So11111111111111111111111111111111111111112',
+      outputMint: 'output-mint',
+      amount: '5000000',
+      exactOutput: true,
+    });
+
+    assert.equal(notional, 250);
+    assert.deepEqual(calls.map(call => call.swapMode), ['ExactOut', 'ExactIn']);
+    assert.equal(calls[1].amount, '2000000000');
+  });
+});


### PR DESCRIPTION
Closes #116\n\n## What changed\n- install one process-wide pre-trade gate for the circuit breaker, safety manager, and global max order size\n- enforce it across Binance, Bybit, Hyperliquid, and MEXC futures handlers and both futures execution services\n- value MEXC volume with its contract multiplier instead of treating contracts as base units\n- value Solana swap inputs in USD through USDC/Jupiter before wallet signing or submission\n- remove stale inline swap handlers that shadowed the guarded modular handlers\n- allow risk-reducing exits past the size cap while still honoring circuit-breaker and kill-switch state\n\n## Verification\n- 
> clodds@1.9.0 ci
> npm run typecheck && npm run test && npm run build


> clodds@1.9.0 typecheck
> tsc --noEmit


> clodds@1.9.0 test
> node --test --import tsx --import ./tests/helpers/test-setup.ts tests/**/*.test.ts

TAP version 13
# Subtest: database uses CLODDS_STATE_DIR
ok 1 - database uses CLODDS_STATE_DIR
  ---
  duration_ms: 151.012792
  type: 'test'
  ...
# Subtest: gateway health and info endpoints respond
ok 2 - gateway health and info endpoints respond
  ---
  duration_ms: 382.674084
  type: 'test'
  ...
# Subtest: market-index search endpoint validates query and returns results
ok 3 - market-index search endpoint validates query and returns results
  ---
  duration_ms: 124.806958
  type: 'test'
  ...
# Subtest: market-index stats endpoint returns stats
ok 4 - market-index stats endpoint returns stats
  ---
  duration_ms: 6.06575
  type: 'test'
  ...
# Subtest: market index sync hits real Kalshi API
ok 5 - market index sync hits real Kalshi API
  ---
  duration_ms: 517.404583
  type: 'test'
  ...
# Subtest: market index sync hits real Manifold API
ok 6 - market index sync hits real Manifold API
  ---
  duration_ms: 527.400708
  type: 'test'
  ...
# Subtest: market index sync hits real Polymarket API
ok 7 - market index sync hits real Polymarket API
  ---
  duration_ms: 447.397208
  type: 'test'
  ...
# Subtest: webchat auth and message flow
ok 8 - webchat auth and message flow
  ---
  duration_ms: 22.052833
  type: 'test'
  ...
# Subtest: webhook HTTP middleware validates signature
ok 9 - webhook HTTP middleware validates signature
  ---
  duration_ms: 31.320792
  type: 'test'
  ...
# Subtest: webhook HTTP middleware enforces rate limit
ok 10 - webhook HTTP middleware enforces rate limit
  ---
  duration_ms: 9.26075
  type: 'test'
  ...
# Subtest: futures pre-trade enforcement
    # Subtest: blocks the exported execution engine above maxOrderSize
    ok 1 - blocks the exported execution engine above maxOrderSize
      ---
      duration_ms: 0.686292
      type: 'test'
      ...
    # Subtest: blocks the dynamically loaded futures engine above maxOrderSize
    ok 2 - blocks the dynamically loaded futures engine above maxOrderSize
      ---
      duration_ms: 0.403792
      type: 'test'
      ...
    # Subtest: checks the breaker before attempting market-price discovery
    ok 3 - checks the breaker before attempting market-price discovery
      ---
      duration_ms: 0.203209
      type: 'test'
      ...
    # Subtest: values MEXC contract volume with the venue contract multiplier
    ok 4 - values MEXC contract volume with the venue contract multiplier
      ---
      duration_ms: 1.190125
      type: 'test'
      ...
    1..4
ok 11 - futures pre-trade enforcement
  ---
  duration_ms: 3.053917
  type: 'suite'
  ...
# Subtest: shared pre-trade gate
    # Subtest: blocks every route when the circuit breaker is tripped
    ok 1 - blocks every route when the circuit breaker is tripped
      ---
      duration_ms: 1.084958
      type: 'test'
      ...
    # Subtest: uses the strictest global and caller-specific order cap
    ok 2 - uses the strictest global and caller-specific order cap
      ---
      duration_ms: 0.29275
      type: 'test'
      ...
    # Subtest: fails closed when a route requires a missing notional
    ok 3 - fails closed when a route requires a missing notional
      ---
      duration_ms: 0.298833
      type: 'test'
      ...
    # Subtest: allows risk-reducing exits over the size cap but still honors kill switches
    ok 4 - allows risk-reducing exits over the size cap but still honors kill switches
      ---
      duration_ms: 0.355625
      type: 'test'
      ...
    1..4
ok 12 - shared pre-trade gate
  ---
  duration_ms: 3.243459
  type: 'suite'
  ...
# Subtest: Solana swap notional valuation
    # Subtest: values USDC inputs directly from base units
    ok 1 - values USDC inputs directly from base units
      ---
      duration_ms: 0.361583
      type: 'test'
      ...
    # Subtest: values non-USDC inputs through a Jupiter USDC quote
    ok 2 - values non-USDC inputs through a Jupiter USDC quote
      ---
      duration_ms: 0.079125
      type: 'test'
      ...
    # Subtest: resolves the required input before valuing exact-output swaps
    ok 3 - resolves the required input before valuing exact-output swaps
      ---
      duration_ms: 0.362916
      type: 'test'
      ...
    1..3
ok 13 - Solana swap notional valuation
  ---
  duration_ms: 1.263667
  type: 'suite'
  ...
# Subtest: sentiment analyzer
    # Subtest: scores bullish text positively
    ok 1 - scores bullish text positively
      ---
      duration_ms: 9.565042
      type: 'test'
      ...
    # Subtest: scores bearish text negatively
    ok 2 - scores bearish text negatively
      ---
      duration_ms: 2.733541
      type: 'test'
      ...
    # Subtest: handles negation (not bullish → bearish)
    ok 3 - handles negation (not bullish → bearish)
      ---
      duration_ms: 1.054708
      type: 'test'
      ...
    # Subtest: scores Fear & Greed numeric value
    ok 4 - scores Fear & Greed numeric value
      ---
      duration_ms: 1.895666
      type: 'test'
      ...
    # Subtest: scores funding rate as contrarian signal
    ok 5 - scores funding rate as contrarian signal
      ---
      duration_ms: 2.425208
      type: 'test'
      ...
    # Subtest: returns neutral for empty/irrelevant text
    ok 6 - returns neutral for empty/irrelevant text
      ---
      duration_ms: 2.955542
      type: 'test'
      ...
    # Subtest: detects politics category
    ok 7 - detects politics category
      ---
      duration_ms: 6.489292
      type: 'test'
      ...
    # Subtest: detects economics category
    ok 8 - detects economics category
      ---
      duration_ms: 2.434291
      type: 'test'
      ...
    1..8
ok 14 - sentiment analyzer
  ---
  duration_ms: 41.667208
  type: 'suite'
  ...
# Subtest: market matcher
    # Subtest: matches by keyword overlap
    ok 1 - matches by keyword overlap
      ---
      duration_ms: 69.006417
      type: 'test'
      ...
    # Subtest: matches by category
    ok 2 - matches by category
      ---
      duration_ms: 18.397542
      type: 'test'
      ...
    # Subtest: returns empty when no markets loaded
    ok 3 - returns empty when no markets loaded
      ---
      duration_ms: 3.970208
      type: 'test'
      ...
    1..3
ok 15 - market matcher
  ---
  duration_ms: 91.761709
  type: 'suite'
  ...
# Subtest: alt-data service
    # Subtest: processes events through full pipeline
    ok 1 - processes events through full pipeline
      ---
      duration_ms: 26.172916
      type: 'test'
      ...
    # Subtest: getRecentSignals returns empty initially
    ok 2 - getRecentSignals returns empty initially
      ---
      duration_ms: 1.376834
      type: 'test'
      ...
    1..2
ok 16 - alt-data service
  ---
  duration_ms: 27.783875
  type: 'suite'
  ...
# Subtest: fear-greed feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 2.843875
      type: 'test'
      ...
    1..1
ok 17 - fear-greed feed
  ---
  duration_ms: 3.028333
  type: 'suite'
  ...
# Subtest: funding-rates feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 3.514083
      type: 'test'
      ...
    1..1
ok 18 - funding-rates feed
  ---
  duration_ms: 3.629541
  type: 'suite'
  ...
# Subtest: reddit feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 3.099583
      type: 'test'
      ...
    1..1
ok 19 - reddit feed
  ---
  duration_ms: 3.257458
  type: 'suite'
  ...
# Subtest: runtime model defaults do not use retired Anthropic IDs
ok 20 - runtime model defaults do not use retired Anthropic IDs
  ---
  duration_ms: 1.716958
  type: 'test'
  ...
# Subtest: Anthropic provider uses active defaults for completion and health checks
ok 21 - Anthropic provider uses active defaults for completion and health checks
  ---
  duration_ms: 15.412292
  type: 'test'
  ...
# Subtest: backtest engine
    # Subtest: creates engine with all methods
    ok 1 - creates engine with all methods
      ---
      duration_ms: 61.812208
      type: 'test'
      ...
    # Subtest: returns empty result for no ticks
    ok 2 - returns empty result for no ticks
      ---
      duration_ms: 7.209209
      type: 'test'
      ...
    # Subtest: executes buy-and-hold strategy on tick data
    ok 3 - executes buy-and-hold strategy on tick data
      ---
      duration_ms: 5.673667
      type: 'test'
      ...
    # Subtest: handles buy and sell signals correctly
    ok 4 - handles buy and sell signals correctly
      ---
      duration_ms: 15.059292
      type: 'test'
      ...
    # Subtest: respects eval interval
    ok 5 - respects eval interval
      ---
      duration_ms: 7.788625
      type: 'test'
      ...
    # Subtest: applies commission and slippage
    ok 6 - applies commission and slippage
      ---
      duration_ms: 2.734542
      type: 'test'
      ...
    # Subtest: finds orderbook snapshots via binary search
    ok 7 - finds orderbook snapshots via binary search
      ---
      duration_ms: 6.744417
      type: 'test'
      ...
    # Subtest: calls strategy init and cleanup
    ok 8 - calls strategy init and cleanup
      ---
      duration_ms: 2.939083
      type: 'test'
      ...
    1..8
ok 22 - backtest engine
  ---
  duration_ms: 114.298792
  type: 'suite'
  ...
# Subtest: backtest monte carlo
    # Subtest: runs monte carlo simulation
    ok 1 - runs monte carlo simulation
      ---
      duration_ms: 10.787917
      type: 'test'
      ...
    # Subtest: handles empty returns
    ok 2 - handles empty returns
      ---
      duration_ms: 6.421709
      type: 'test'
      ...
    1..2
ok 23 - backtest monte carlo
  ---
  duration_ms: 17.378167
  type: 'suite'
  ...
# Subtest: backtest metrics
    # Subtest: calculates correct metrics for winning trades
    ok 1 - calculates correct metrics for winning trades
      ---
      duration_ms: 2.324542
      type: 'test'
      ...
    1..1
ok 24 - backtest metrics
  ---
  duration_ms: 2.39625
  type: 'suite'
  ...
# Subtest: built-in strategies
    # Subtest: mean reversion strategy has correct config
    ok 1 - mean reversion strategy has correct config
      ---
      duration_ms: 28.370375
      type: 'test'
      ...
    # Subtest: momentum strategy has correct config
    ok 2 - momentum strategy has correct config
      ---
      duration_ms: 0.871916
      type: 'test'
      ...
    # Subtest: strategies accept custom params
    ok 3 - strategies accept custom params
      ---
      duration_ms: 0.985333
      type: 'test'
      ...
    1..3
ok 25 - built-in strategies
  ---
  duration_ms: 30.437791
  type: 'suite'
  ...
# Subtest: bittensor wallet
    # Subtest: raoToTao converts 1 billion rao to 1 TAO
    ok 1 - raoToTao converts 1 billion rao to 1 TAO
      ---
      duration_ms: 0.359083
      type: 'test'
      ...
    1..1
ok 26 - bittensor wallet
  ---
  duration_ms: 0.769083
  type: 'suite'
  ...
# Subtest: bittensor python-runner
    # Subtest: sanitizeArg strips dangerous shell characters
    ok 1 - sanitizeArg strips dangerous shell characters
      ---
      duration_ms: 75.528042
      type: 'test'
      ...
    # Subtest: createPythonRunner returns object with exec, spawn, btcli
    ok 2 - createPythonRunner returns object with exec, spawn, btcli
      ---
      duration_ms: 5.007291
      type: 'test'
      ...
    1..2
ok 27 - bittensor python-runner
  ---
  duration_ms: 80.680041
  type: 'suite'
  ...
# Subtest: bittensor chutes manager
    # Subtest: initializes with GPU nodes from config
    ok 1 - initializes with GPU nodes from config
      ---
      duration_ms: 27.302125
      type: 'test'
      ...
    # Subtest: addGpuNode and removeGpuNode work correctly
    ok 2 - addGpuNode and removeGpuNode work correctly
      ---
      duration_ms: 11.786125
      type: 'test'
      ...
    # Subtest: getInvocationStats returns zero when not started
    ok 3 - getInvocationStats returns zero when not started
      ---
      duration_ms: 16.694
      type: 'test'
      ...
    1..3
ok 28 - bittensor chutes manager
  ---
  duration_ms: 56.996916
  type: 'suite'
  ...
# Subtest: bittensor persistence
    # Subtest: init creates all three tables
    ok 1 - init creates all three tables
      ---
      duration_ms: 8.015666
      type: 'test'
      ...
    # Subtest: saveEarnings and getEarnings round-trip
    ok 2 - saveEarnings and getEarnings round-trip
      ---
      duration_ms: 4.33825
      type: 'test'
      ...
    # Subtest: saveMinerStatus and getMinerStatus round-trip
    ok 3 - saveMinerStatus and getMinerStatus round-trip
      ---
      duration_ms: 1.714625
      type: 'test'
      ...
    # Subtest: saveMinerStatus upserts on conflict
    ok 4 - saveMinerStatus upserts on conflict
      ---
      duration_ms: 2.057291
      type: 'test'
      ...
    # Subtest: getMinerStatuses returns all rows
    ok 5 - getMinerStatuses returns all rows
      ---
      duration_ms: 1.067375
      type: 'test'
      ...
    # Subtest: logCost and getCosts round-trip
    ok 6 - logCost and getCosts round-trip
      ---
      duration_ms: 3.28925
      type: 'test'
      ...
    # Subtest: getMinerStatus returns null for missing entry
    ok 7 - getMinerStatus returns null for missing entry
      ---
      duration_ms: 1.040916
      type: 'test'
      ...
    1..7
ok 29 - bittensor persistence
  ---
  duration_ms: 22.242417
  type: 'suite'
  ...
# Subtest: bittensor handler
    # Subtest: returns error when service is not set
    ok 1 - returns error when service is not set
      ---
      duration_ms: 4.003834
      type: 'test'
      ...
    # Subtest: returns status when service is set
    ok 2 - returns status when service is set
      ---
      duration_ms: 0.885791
      type: 'test'
      ...
    # Subtest: returns earnings for a period
    ok 3 - returns earnings for a period
      ---
      duration_ms: 1.104792
      type: 'test'
      ...
    # Subtest: returns error for unknown action
    ok 4 - returns error for unknown action
      ---
      duration_ms: 0.607917
      type: 'test'
      ...
    # Subtest: requires subnetId for start/stop/register
    ok 5 - requires subnetId for start/stop/register
      ---
      duration_ms: 2.140916
      type: 'test'
      ...
    1..5
ok 30 - bittensor handler
  ---
  duration_ms: 9.156791
  type: 'suite'
  ...
# Subtest: bittensor router
    # Subtest: creates a router with all expected routes
    ok 1 - creates a router with all expected routes
      ---
      duration_ms: 77.85575
      type: 'test'
      ...
    1..1
ok 31 - bittensor router
  ---
  duration_ms: 77.991208
  type: 'suite'
  ...
# Subtest: BotManager
    # Subtest: creates bot manager with default config
    ok 1 - creates bot manager with default config
      ---
      duration_ms: 17.528417
      type: 'test'
      ...
    # Subtest: registers and lists strategies
    ok 2 - registers and lists strategies
      ---
      duration_ms: 49.796416
      type: 'test'
      ...
    # Subtest: getStrategy returns Strategy by ID
    ok 3 - getStrategy returns Strategy by ID
      ---
      duration_ms: 5.11275
      type: 'test'
      ...
    # Subtest: getStrategy returns null for unknown ID
    ok 4 - getStrategy returns null for unknown ID
      ---
      duration_ms: 2.925
      type: 'test'
      ...
    # Subtest: returns bot statuses
    ok 5 - returns bot statuses
      ---
      duration_ms: 5.338584
      type: 'test'
      ...
    # Subtest: getTradeLogger returns a logger instance
    ok 6 - getTradeLogger returns a logger instance
      ---
      duration_ms: 2.809667
      type: 'test'
      ...
    1..6
ok 32 - BotManager
  ---
  duration_ms: 84.548167
  type: 'suite'
  ...
# Subtest: BotManager with shared TradeLogger
    # Subtest: uses external tradeLogger when provided
    ok 1 - uses external tradeLogger when provided
      ---
      duration_ms: 8.878666
      type: 'test'
      ...
    # Subtest: creates own tradeLogger when not provided
    ok 2 - creates own tradeLogger when not provided
      ---
      duration_ms: 1.365666
      type: 'test'
      ...
    1..2
ok 33 - BotManager with shared TradeLogger
  ---
  duration_ms: 10.905417
  type: 'suite'
  ...
# Subtest: BotManager with execution callbacks
    # Subtest: accepts executeOrder callback
    ok 1 - accepts executeOrder callback
      ---
      duration_ms: 2.590583
      type: 'test'
      ...
    # Subtest: accepts getPrice callback
    ok 2 - accepts getPrice callback
      ---
      duration_ms: 1.973
      type: 'test'
      ...
    # Subtest: accepts getMarket callback
    ok 3 - accepts getMarket callback
      ---
      duration_ms: 1.52425
      type: 'test'
      ...
    # Subtest: accepts getPortfolio callback
    ok 4 - accepts getPortfolio callback
      ---
      duration_ms: 5.847541
      type: 'test'
      ...
    1..4
ok 34 - BotManager with execution callbacks
  ---
  duration_ms: 12.257583
  type: 'suite'
  ...
# Subtest: StrategyBuilder
    # Subtest: creates strategy builder
    ok 1 - creates strategy builder
      ---
      duration_ms: 3.768167
      type: 'test'
      ...
    # Subtest: lists available templates
    ok 2 - lists available templates
      ---
      duration_ms: 1.275541
      type: 'test'
      ...
    # Subtest: validates a strategy definition
    ok 3 - validates a strategy definition
      ---
      duration_ms: 3.49775
      type: 'test'
      ...
    1..3
ok 35 - StrategyBuilder
  ---
  duration_ms: 8.780416
  type: 'suite'
  ...
# Subtest: Trading Adapters
    # Subtest: creates crypto HFT adapter as Strategy
    ok 1 - creates crypto HFT adapter as Strategy
      ---
      duration_ms: 9.820417
      type: 'test'
      ...
    # Subtest: creates divergence adapter as Strategy
    ok 2 - creates divergence adapter as Strategy
      ---
      duration_ms: 2.833125
      type: 'test'
      ...
    # Subtest: crypto HFT adapter evaluate returns empty when engine not started
    ok 3 - crypto HFT adapter evaluate returns empty when engine not started
      ---
      duration_ms: 2.652
      type: 'test'
      ...
    # Subtest: divergence adapter evaluate returns empty when engine not started
    ok 4 - divergence adapter evaluate returns empty when engine not started
      ---
      duration_ms: 9.028917
      type: 'test'
      ...
    # Subtest: adapters can be registered in BotManager
    ok 5 - adapters can be registered in BotManager
      ---
      duration_ms: 3.348583
      type: 'test'
      ...
    1..5
ok 36 - Trading Adapters
  ---
  duration_ms: 28.106167
  type: 'suite'
  ...
# Subtest: Config env var overrides
    # Subtest: maps Discord credentials into the runtime channel config
    ok 1 - maps Discord credentials into the runtime channel config
      ---
      duration_ms: 37.740417
      type: 'test'
      ...
    # Subtest: MARKET_MAKING_ENABLED sets config.trading.marketMaking.enabled
    ok 2 - MARKET_MAKING_ENABLED sets config.trading.marketMaking.enabled
      ---
      duration_ms: 1.940958
      type: 'test'
      ...
    # Subtest: CRYPTO_HFT_ENABLED sets config.trading.cryptoHft.enabled
    ok 3 - CRYPTO_HFT_ENABLED sets config.trading.cryptoHft.enabled
      ---
      duration_ms: 0.939084
      type: 'test'
      ...
    # Subtest: HFT_DIVERGENCE_ENABLED sets config.trading.hftDivergence.enabled
    ok 4 - HFT_DIVERGENCE_ENABLED sets config.trading.hftDivergence.enabled
      ---
      duration_ms: 1.97375
      type: 'test'
      ...
    1..4
ok 37 - Config env var overrides
  ---
  duration_ms: 42.803167
  type: 'suite'
  ...
# [2026-09-12 03:54:32.147 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# [2026-09-12 03:54:32.150 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# [2026-09-12 03:54:32.151 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# [2026-09-12 03:54:32.153 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# Subtest: risk command parses settings and updates user
ok 38 - risk command parses settings and updates user
  ---
  duration_ms: 2.499125
  type: 'test'
  ...
# Subtest: risk command rejects invalid input
ok 39 - risk command rejects invalid input
  ---
  duration_ms: 0.315542
  type: 'test'
  ...
# Subtest: digest command parses time and enables
ok 40 - digest command parses time and enables
  ---
  duration_ms: 0.904208
  type: 'test'
  ...
# Subtest: compare command parses platforms and limit
ok 41 - compare command parses platforms and limit
  ---
  duration_ms: 33.071875
  type: 'test'
  ...
# Subtest: markets command errors on empty args
ok 42 - markets command errors on empty args
  ---
  duration_ms: 0.206166
  type: 'test'
  ...
# Subtest: markets command treats single token as query
ok 43 - markets command treats single token as query
  ---
  duration_ms: 0.129291
  type: 'test'
  ...
# Subtest: arbitrage command parses args and uses minEdge
ok 44 - arbitrage command parses args and uses minEdge
  ---
  duration_ms: 0.373459
  type: 'test'
  ...
# Subtest: pnl command parses args and passes since/limit to db
ok 45 - pnl command parses args and passes since/limit to db
  ---
  duration_ms: 0.287333
  type: 'test'
  ...
# Subtest: resolveStateDir uses override
ok 46 - resolveStateDir uses override
  ---
  duration_ms: 0.393375
  type: 'test'
  ...
# Subtest: resolveConfigPath uses override
ok 47 - resolveConfigPath uses override
  ---
  duration_ms: 0.060708
  type: 'test'
  ...
# Subtest: resolveWorkspaceDir uses override
ok 48 - resolveWorkspaceDir uses override
  ---
  duration_ms: 0.050542
  type: 'test'
  ...
# Subtest: fast-broadcast byte parity with ethers wallet.sendTransaction
    # Subtest: produces the exact same signed raw transaction bytes as the native ethers path
    ok 1 - produces the exact same signed raw transaction bytes as the native ethers path
      ---
      duration_ms: 162.932291
      type: 'test'
      ...
    1..1
ok 49 - fast-broadcast byte parity with ethers wallet.sendTransaction
  ---
  duration_ms: 163.650875
  type: 'suite'
  ...
# Subtest: fast-broadcast (Rust worker via TS wrapper)
ok 50 - fast-broadcast (Rust worker via TS wrapper) # SKIP fast-broadcast Rust binary not built — run `cargo build` in rust/fast-broadcast/
  ---
  duration_ms: 0.526208
  type: 'suite'
  ...
# Subtest: market index search boosts text matches
ok 51 - market index search boosts text matches
  ---
  duration_ms: 0.790625
  type: 'test'
  ...
# Subtest: market index search applies platform weights
ok 52 - market index search applies platform weights
  ---
  duration_ms: 0.160625
  type: 'test'
  ...
# Subtest: market index search honors minScore
ok 53 - market index search honors minScore
  ---
  duration_ms: 0.167459
  type: 'test'
  ...
# Subtest: ml-pipeline types
    # Subtest: exports default quality gates
    ok 1 - exports default quality gates
      ---
      duration_ms: 6.546416
      type: 'test'
      ...
    1..1
ok 54 - ml-pipeline types
  ---
  duration_ms: 7.453083
  type: 'suite'
  ...
# Subtest: combinedToMarketFeatures
    # Subtest: handles null combined features
    ok 1 - handles null combined features
      ---
      duration_ms: 28.80625
      type: 'test'
      ...
    # Subtest: maps tick features correctly
    ok 2 - maps tick features correctly
      ---
      duration_ms: 3.45525
      type: 'test'
      ...
    # Subtest: maps orderbook features correctly
    ok 3 - maps orderbook features correctly
      ---
      duration_ms: 3.137083
      type: 'test'
      ...
    1..3
ok 55 - combinedToMarketFeatures
  ---
  duration_ms: 36.05275
  type: 'suite'
  ...
# Subtest: ml collector
    # Subtest: creates ml_training_samples table on init
    ok 1 - creates ml_training_samples table on init
      ---
      duration_ms: 12.845333
      type: 'test'
      ...
    # Subtest: captures signal on executed event
    ok 2 - captures signal on executed event
      ---
      duration_ms: 2.623542
      type: 'test'
      ...
    # Subtest: captures signal on dry_run event
    ok 3 - captures signal on dry_run event
      ---
      duration_ms: 4.543541
      type: 'test'
      ...
    # Subtest: returns sample counts
    ok 4 - returns sample counts
      ---
      duration_ms: 1.411541
      type: 'test'
      ...
    # Subtest: stops cleanly
    ok 5 - stops cleanly
      ---
      duration_ms: 1.17475
      type: 'test'
      ...
    1..5
ok 56 - ml collector
  ---
  duration_ms: 23.245583
  type: 'suite'
  ...
# Subtest: ml trainer
    # Subtest: creates trainer with stats
    ok 1 - creates trainer with stats
      ---
      duration_ms: 13.9225
      type: 'test'
      ...
    # Subtest: skips training with too few samples
    ok 2 - skips training with too few samples
      ---
      duration_ms: 2.460583
      type: 'test'
      ...
    # Subtest: starts and stops cleanly
    ok 3 - starts and stops cleanly
      ---
      duration_ms: 2.423041
      type: 'test'
      ...
    1..3
ok 57 - ml trainer
  ---
  duration_ms: 18.974666
  type: 'suite'
  ...
# Subtest: ml pipeline factory
    # Subtest: creates pipeline with model
    ok 1 - creates pipeline with model
      ---
      duration_ms: 2.786959
      type: 'test'
      ...
    # Subtest: returns stats
    ok 2 - returns stats
      ---
      duration_ms: 0.8885
      type: 'test'
      ...
    # Subtest: starts and stops with signal router
    ok 3 - starts and stops with signal router
      ---
      duration_ms: 1.170583
      type: 'test'
      ...
    1..3
ok 58 - ml pipeline factory
  ---
  duration_ms: 5.125708
  type: 'suite'
  ...
# Subtest: signal router with ML model
    # Subtest: accepts optional mlModel parameter
    ok 1 - accepts optional mlModel parameter
      ---
      duration_ms: 4.479125
      type: 'test'
      ...
    # Subtest: works without mlModel (backward compatible)
    ok 2 - works without mlModel (backward compatible)
      ---
      duration_ms: 0.633875
      type: 'test'
      ...
    1..2
ok 59 - signal router with ML model
  ---
  duration_ms: 5.212083
  type: 'suite'
  ...
# Subtest: multi-hop arbitrage planner
    # Subtest: finds a profitable three-hop cycle
    ok 1 - finds a profitable three-hop cycle
      ---
      duration_ms: 0.898083
      type: 'test'
      ...
    # Subtest: marks all-solana paths as atomic bundles when every hop is bundle-eligible
    ok 2 - marks all-solana paths as atomic bundles when every hop is bundle-eligible
      ---
      duration_ms: 0.219792
      type: 'test'
      ...
    # Subtest: marks all-evm paths as exact-in for deterministic entry sizing
    ok 3 - marks all-evm paths as exact-in for deterministic entry sizing
      ---
      duration_ms: 0.202125
      type: 'test'
      ...
    1..3
ok 60 - multi-hop arbitrage planner
  ---
  duration_ms: 1.804666
  type: 'suite'
  ...
# Subtest: multichain getRaceUrls
    # Subtest: defaults to just the primary RPC when no fallbacks are configured
    ok 1 - defaults to just the primary RPC when no fallbacks are configured
      ---
      duration_ms: 645.332
      type: 'test'
      ...
    # Subtest: includes configured fallbacks after the primary, trimmed
    ok 2 - includes configured fallbacks after the primary, trimmed
      ---
      duration_ms: 350.115208
      type: 'test'
      ...
    # Subtest: dedupes a fallback that matches the primary
    ok 3 - dedupes a fallback that matches the primary
      ---
      duration_ms: 345.764917
      type: 'test'
      ...
    1..3
ok 61 - multichain getRaceUrls
  ---
  duration_ms: 1341.792834
  type: 'suite'
  ...
# Subtest: opportunity hft integration
    # Subtest: builds a live venue plan from an opportunity and uses outcome token ids for polymarket
    ok 1 - builds a live venue plan from an opportunity and uses outcome token ids for polymarket
      ---
      duration_ms: 1.159334
      type: 'test'
      ...
    # Subtest: builds live linked-market venue plans from market identity groups
    ok 2 - builds live linked-market venue plans from market identity groups
      ---
      duration_ms: 0.572917
      type: 'test'
      ...
    # Subtest: derives NO-side pricing from binary yes orderbooks when venue lookup is market-level only
    ok 3 - derives NO-side pricing from binary yes orderbooks when venue lookup is market-level only
      ---
      duration_ms: 0.653875
      type: 'test'
      ...
    1..3
ok 62 - opportunity hft integration
  ---
  duration_ms: 2.876417
  type: 'suite'
  ...
# Subtest: Polymarket V2 order signer byte parity with ethers EIP-712
    # Subtest: produces a byte-identical signature to an independent ethers reference (standard exchange, BUY)
    ok 1 - produces a byte-identical signature to an independent ethers reference (standard exchange, BUY)
      ---
      duration_ms: 66.898208
      type: 'test'
      ...
    # Subtest: produces a byte-identical signature to an independent ethers reference (negRisk exchange, SELL)
    ok 2 - produces a byte-identical signature to an independent ethers reference (negRisk exchange, SELL)
      ---
      duration_ms: 6.358541
      type: 'test'
      ...
    # Subtest: defaults metadata/builder to 32 zero bytes and rejects POLY_1271
    ok 3 - defaults metadata/builder to 32 zero bytes and rejects POLY_1271
      ---
      duration_ms: 1.373125
      type: 'test'
      ...
    1..3
ok 63 - Polymarket V2 order signer byte parity with ethers EIP-712
  ---
  duration_ms: 75.385791
  type: 'suite'
  ...
# Subtest: enforceMaxOrderSize blocks oversized order
ok 64 - enforceMaxOrderSize blocks oversized order
  ---
  duration_ms: 1.280292
  type: 'test'
  ...
# Subtest: enforceMaxOrderSize allows small or invalid notional
ok 65 - enforceMaxOrderSize allows small or invalid notional
  ---
  duration_ms: 0.236417
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks maxTotalExposure
ok 66 - enforceExposureLimits blocks maxTotalExposure
  ---
  duration_ms: 0.67625
  type: 'test'
  ...
# Subtest: enforceExposureLimits ignores non-positive notional
ok 67 - enforceExposureLimits ignores non-positive notional
  ---
  duration_ms: 0.103375
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks maxPositionValue
ok 68 - enforceExposureLimits blocks maxPositionValue
  ---
  duration_ms: 0.171083
  type: 'test'
  ...
# Subtest: enforceExposureLimits skips maxPositionValue when market/outcome missing
ok 69 - enforceExposureLimits skips maxPositionValue when market/outcome missing
  ---
  duration_ms: 0.069334
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks stop-loss threshold
ok 70 - enforceExposureLimits blocks stop-loss threshold
  ---
  duration_ms: 0.082791
  type: 'test'
  ...
# Subtest: enforceExposureLimits returns null when no limits configured
ok 71 - enforceExposureLimits returns null when no limits configured
  ---
  duration_ms: 0.059417
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage report summarizes reuse targets
ok 72 - rust-hft-arbitrage report summarizes reuse targets
  ---
  duration_ms: 0.475209
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage venues command lists concrete venues
ok 73 - rust-hft-arbitrage venues command lists concrete venues
  ---
  duration_ms: 0.092291
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan help shows usage without hitting the network
ok 74 - rust-hft-arbitrage scan help shows usage without hitting the network
  ---
  duration_ms: 0.113667
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan rejects an unknown family before scanning
ok 75 - rust-hft-arbitrage scan rejects an unknown family before scanning
  ---
  duration_ms: 0.116125
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan requires size and tokens
ok 76 - rust-hft-arbitrage scan requires size and tokens
  ---
  duration_ms: 0.047334
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan requires a valid chain for evm/cross families
ok 77 - rust-hft-arbitrage scan requires a valid chain for evm/cross families
  ---
  duration_ms: 0.064208
  type: 'test'
  ...
# Subtest: signal router
    # Subtest: creates with start/stop lifecycle
    ok 1 - creates with start/stop lifecycle
      ---
      duration_ms: 33.985042
      type: 'test'
      ...
    # Subtest: rejects signals below min strength
    ok 2 - rejects signals below min strength
      ---
      duration_ms: 63.725833
      type: 'test'
      ...
    # Subtest: rejects neutral direction signals
    ok 3 - rejects neutral direction signals
      ---
      duration_ms: 60.51075
      type: 'test'
      ...
    # Subtest: filters by signal type
    ok 4 - filters by signal type
      ---
      duration_ms: 52.620375
      type: 'test'
      ...
    # Subtest: filters by platform
    ok 5 - filters by platform
      ---
      duration_ms: 53.9405
      type: 'test'
      ...
    # Subtest: enforces per-market cooldown
    ok 6 - enforces per-market cooldown
      ---
      duration_ms: 108.691792
      type: 'test'
      ...
    # Subtest: rejects when no price data available
    ok 7 - rejects when no price data available
      ---
      duration_ms: 54.4615
      type: 'test'
      ...
    # Subtest: tracks recent executions
    ok 8 - tracks recent executions
      ---
      duration_ms: 51.677833
      type: 'test'
      ...
    # Subtest: respects daily loss limit
    ok 9 - respects daily loss limit
      ---
      duration_ms: 52.255166
      type: 'test'
      ...
    # Subtest: enforces max concurrent positions
    ok 10 - enforces max concurrent positions
      ---
      duration_ms: 51.852792
      type: 'test'
      ...
    # Subtest: updateConfig changes behavior
    ok 11 - updateConfig changes behavior
      ---
      duration_ms: 1.227292
      type: 'test'
      ...
    # Subtest: resetDailyStats clears counters
    ok 12 - resetDailyStats clears counters
      ---
      duration_ms: 51.674083
      type: 'test'
      ...
    1..12
ok 78 - signal router
  ---
  duration_ms: 637.706709
  type: 'suite'
  ...
# Subtest: computeWeightedAverageFill
    # Subtest: fills fully within a single level
    ok 1 - fills fully within a single level
      ---
      duration_ms: 0.404584
      type: 'test'
      ...
    # Subtest: walks multiple levels and reports partial fills when depth runs out
    ok 2 - walks multiple levels and reports partial fills when depth runs out
      ---
      duration_ms: 0.104458
      type: 'test'
      ...
    # Subtest: returns null for empty or invalid book depth
    ok 3 - returns null for empty or invalid book depth
      ---
      duration_ms: 0.046292
      type: 'test'
      ...
    1..3
ok 79 - computeWeightedAverageFill
  ---
  duration_ms: 0.948625
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (solana)
    # Subtest: finds a crossed plan between two solana venues and prices it sanely
    ok 1 - finds a crossed plan between two solana venues and prices it sanely
      ---
      duration_ms: 12.660666
      type: 'test'
      ...
    # Subtest: picks pumpswap as the cheapest venue among three solana AMMs
    ok 2 - picks pumpswap as the cheapest venue among three solana AMMs
      ---
      duration_ms: 0.944083
      type: 'test'
      ...
    # Subtest: routes a failing venue into skipped without dropping the rest
    ok 3 - routes a failing venue into skipped without dropping the rest
      ---
      duration_ms: 0.553542
      type: 'test'
      ...
    1..3
ok 80 - scanVenueArbitrage (solana)
  ---
  duration_ms: 14.334416
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (evm)
    # Subtest: finds a crossed plan between uniswap and lighter on arbitrum
    ok 1 - finds a crossed plan between uniswap and lighter on arbitrum
      ---
      duration_ms: 0.728041
      type: 'test'
      ...
    # Subtest: rejects lighter quoting outside arbitrum
    ok 2 - rejects lighter quoting outside arbitrum
      ---
      duration_ms: 0.0995
      type: 'test'
      ...
    1..2
ok 81 - scanVenueArbitrage (evm)
  ---
  duration_ms: 1.017042
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (cross-chain)
    # Subtest: combines solana and evm legs and flags the pre-positioned inventory assumption
    ok 1 - combines solana and evm legs and flags the pre-positioned inventory assumption
      ---
      duration_ms: 0.455709
      type: 'test'
      ...
    1..1
ok 82 - scanVenueArbitrage (cross-chain)
  ---
  duration_ms: 0.573375
  type: 'suite'
  ...
# Subtest: venue arbitrage planner
    # Subtest: finds a net-positive crossed venue arbitrage plan
    ok 1 - finds a net-positive crossed venue arbitrage plan
      ---
      duration_ms: 1.128708
      type: 'test'
      ...
    # Subtest: drops stale quotes before planning
    ok 2 - drops stale quotes before planning
      ---
      duration_ms: 0.108042
      type: 'test'
      ...
    # Subtest: penalizes slower venues enough to prefer the faster route
    ok 3 - penalizes slower venues enough to prefer the faster route
      ---
      duration_ms: 0.264292
      type: 'test'
      ...
    # Subtest: supports maker-taker execution sequencing
    ok 4 - supports maker-taker execution sequencing
      ---
      duration_ms: 0.130041
      type: 'test'
      ...
    # Subtest: can surface queue-based maker opportunities when crossed-market mode is disabled
    ok 5 - can surface queue-based maker opportunities when crossed-market mode is disabled
      ---
      duration_ms: 0.147167
      type: 'test'
      ...
    # Subtest: accepts Solana and EVM venue identifiers in the planner
    ok 6 - accepts Solana and EVM venue identifiers in the planner
      ---
      duration_ms: 0.735375
      type: 'test'
      ...
    1..6
ok 83 - venue arbitrage planner
  ---
  duration_ms: 3.332125
  type: 'suite'
  ...
# Subtest: webhook manager rejects invalid signature
ok 84 - webhook manager rejects invalid signature
  ---
  duration_ms: 0.705958
  type: 'test'
  ...
# Subtest: webhook manager enforces rate limit
ok 85 - webhook manager enforces rate limit
  ---
  duration_ms: 0.177125
  type: 'test'
  ...
1..85
# tests 183
# suites 43
# pass 183
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 4472.04325

> clodds@1.9.0 build
> tsc && node -e "const{cpSync,readdirSync}=require('fs'),p=require('path');readdirSync('src/skills/bundled',{withFileTypes:true}).filter(d=>d.isDirectory()).forEach(d=>{const s=p.join('src/skills/bundled',d.name,'SKILL.md'),t=p.join('dist/skills/bundled',d.name,'SKILL.md');try{cpSync(s,t)}catch{}})"\n- 183 tests passed\n- TypeScript typecheck passed\n- production build passed