### PR TITLE
fix: enforce safety checks for batch orders

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -3330,11 +3330,34 @@ export function createExecutionService(config: ExecutionConfig): ExecutionServic
       const indexedOrders = orders.map((o, i) => ({ order: o, index: i }));
       const resultsByIndex: OrderResult[] = new Array(orders.length);
 
-      const polyIndexed = indexedOrders.filter(o => o.order.platform === 'polymarket');
-      const kalshiIndexed = indexedOrders.filter(o => o.order.platform === 'kalshi');
-      const opinionIndexed = indexedOrders.filter(o => o.order.platform === 'opinion');
-      const predictfunIndexed = indexedOrders.filter(o => o.order.platform === 'predictfun');
-      const otherIndexed = indexedOrders.filter(o => o.order.platform !== 'opinion' && o.order.platform !== 'polymarket' && o.order.platform !== 'kalshi' && o.order.platform !== 'predictfun');
+      // Batch transports must enforce the same pre-trade checks as single orders.
+      // Invalid and dry-run items are resolved locally and excluded from every
+      // venue batch below, while valid items retain their original result index.
+      const executableOrders = indexedOrders.filter(({ order, index }) => {
+        const error = validateOrder({ ...order, orderType: 'GTC' });
+        if (error) {
+          resultsByIndex[index] = { success: false, error };
+          return false;
+        }
+
+        if (config.dryRun) {
+          logger.info({ ...order, dryRun: true }, 'Dry run batch order');
+          resultsByIndex[index] = {
+            success: true,
+            orderId: `dry_${randomBytes(8).toString('hex')}`,
+            status: 'open',
+          };
+          return false;
+        }
+
+        return true;
+      });
+
+      const polyIndexed = executableOrders.filter(o => o.order.platform === 'polymarket');
+      const kalshiIndexed = executableOrders.filter(o => o.order.platform === 'kalshi');
+      const opinionIndexed = executableOrders.filter(o => o.order.platform === 'opinion');
+      const predictfunIndexed = executableOrders.filter(o => o.order.platform === 'predictfun');
+      const otherIndexed = executableOrders.filter(o => o.order.platform !== 'opinion' && o.order.platform !== 'polymarket' && o.order.platform !== 'kalshi' && o.order.platform !== 'predictfun');
 
       // Execute Polymarket batch if we have Polymarket orders and config
       if (polyIndexed.length > 0 && config.polymarket) {
@@ -3457,7 +3480,12 @@ export function createExecutionService(config: ExecutionConfig): ExecutionServic
         }
       }
 
-      const results = resultsByIndex;
+      const results = resultsByIndex.map((result, index) => {
+        const resolved = result ?? { success: false, error: 'Missing batch result' };
+        const order = orders[index];
+        recordOrderToCircuitBreaker(resolved, order.price * order.size);
+        return resolved;
+      });
 
       return results;
     },

--- a/tests/execution/batch-order-safety.test.ts
+++ b/tests/execution/batch-order-safety.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createCircuitBreaker } from '../../src/execution/circuit-breaker';
+import { createExecutionService } from '../../src/execution';
+
+function order(overrides: Record<string, unknown> = {}) {
+  return {
+    platform: 'polymarket' as const,
+    marketId: 'market-1',
+    tokenId: 'token-1',
+    outcome: 'yes' as const,
+    side: 'buy' as const,
+    price: 0.5,
+    size: 10,
+    ...overrides,
+  };
+}
+
+describe('batch order pre-trade safety', () => {
+  it('returns dry-run results without requiring venue configuration', async () => {
+    const service = createExecutionService({ dryRun: true });
+
+    const results = await service.placeOrdersBatch([
+      order(),
+      order({ platform: 'kalshi', marketId: 'KX-TEST', tokenId: undefined }),
+    ]);
+
+    assert.equal(results.length, 2);
+    assert.ok(results.every(result => result.success));
+    assert.ok(results.every(result => result.orderId?.startsWith('dry_')));
+  });
+
+  it('rejects invalid and oversized items before dry-run handling', async () => {
+    const service = createExecutionService({ dryRun: true, maxOrderSize: 100 });
+
+    const results = await service.placeOrdersBatch([
+      order({ price: Number.NaN }),
+      order({ price: 0.9, size: 200 }),
+      order({ price: 0.5, size: 10 }),
+    ]);
+
+    assert.match(results[0].error ?? '', /must be finite numbers/);
+    assert.match(results[1].error ?? '', /exceeds max \$100/);
+    assert.equal(results[2].success, true);
+    assert.ok(results[2].orderId?.startsWith('dry_'));
+  });
+
+  it('blocks every batch item when the circuit breaker is tripped', async () => {
+    const service = createExecutionService({ dryRun: true });
+    const breaker = createCircuitBreaker();
+    breaker.trip('manual');
+    service.setCircuitBreaker(breaker);
+
+    const results = await service.placeOrdersBatch([order(), order({ marketId: 'market-2' })]);
+
+    assert.equal(results.length, 2);
+    assert.ok(results.every(result => !result.success));
+    assert.ok(results.every(result => result.error?.includes('circuit breaker')));
+    breaker.stop();
+  });
+});


### PR DESCRIPTION
Closes #115\n\n## What changed\n- validate every batch item before it reaches a venue helper\n- preserve input/result ordering while excluding rejected items from venue batches\n- honor dry-run mode locally so no venue batch call can submit a real order\n- record batch outcomes in the circuit breaker consistently with single-order execution\n- return an explicit failure instead of leaving sparse results when a venue omits an item\n\n## Verification\n- 
> clodds@1.9.0 ci
> npm run typecheck && npm run test && npm run build


> clodds@1.9.0 typecheck
> tsc --noEmit


> clodds@1.9.0 test
> node --test --import tsx --import ./tests/helpers/test-setup.ts tests/**/*.test.ts

TAP version 13
# Subtest: batch order pre-trade safety
    # Subtest: returns dry-run results without requiring venue configuration
    ok 1 - returns dry-run results without requiring venue configuration
      ---
      duration_ms: 0.810875
      type: 'test'
      ...
    # Subtest: rejects invalid and oversized items before dry-run handling
    ok 2 - rejects invalid and oversized items before dry-run handling
      ---
      duration_ms: 0.187417
      type: 'test'
      ...
    # Subtest: blocks every batch item when the circuit breaker is tripped
    ok 3 - blocks every batch item when the circuit breaker is tripped
      ---
      duration_ms: 1.554041
      type: 'test'
      ...
    1..3
ok 1 - batch order pre-trade safety
  ---
  duration_ms: 3.027208
  type: 'suite'
  ...
# [2026-09-12 04:00:47.586 +0100] [31mERROR[39m: [36mCircuit breaker TRIPPED[39m
#     reason: "manual"
#     sessionPnL: 0
#     consecutiveLosses: 0
#     errorRate: 0
#     dailyTrades: 0
# Subtest: database uses CLODDS_STATE_DIR
ok 2 - database uses CLODDS_STATE_DIR
  ---
  duration_ms: 260.215667
  type: 'test'
  ...
# Subtest: gateway health and info endpoints respond
ok 3 - gateway health and info endpoints respond
  ---
  duration_ms: 508.880667
  type: 'test'
  ...
# Subtest: market-index search endpoint validates query and returns results
ok 4 - market-index search endpoint validates query and returns results
  ---
  duration_ms: 233.788417
  type: 'test'
  ...
# Subtest: market-index stats endpoint returns stats
ok 5 - market-index stats endpoint returns stats
  ---
  duration_ms: 7.219875
  type: 'test'
  ...
# Subtest: market index sync hits real Kalshi API
ok 6 - market index sync hits real Kalshi API
  ---
  duration_ms: 490.489584
  type: 'test'
  ...
# Subtest: market index sync hits real Manifold API
ok 7 - market index sync hits real Manifold API
  ---
  duration_ms: 542.133125
  type: 'test'
  ...
# Subtest: market index sync hits real Polymarket API
ok 8 - market index sync hits real Polymarket API
  ---
  duration_ms: 458.281708
  type: 'test'
  ...
# Subtest: webchat auth and message flow
ok 9 - webchat auth and message flow
  ---
  duration_ms: 18.229167
  type: 'test'
  ...
# Subtest: webhook HTTP middleware validates signature
ok 10 - webhook HTTP middleware validates signature
  ---
  duration_ms: 84.416292
  type: 'test'
  ...
# Subtest: webhook HTTP middleware enforces rate limit
ok 11 - webhook HTTP middleware enforces rate limit
  ---
  duration_ms: 10.969792
  type: 'test'
  ...
# Subtest: futures pre-trade enforcement
    # Subtest: blocks the exported execution engine above maxOrderSize
    ok 1 - blocks the exported execution engine above maxOrderSize
      ---
      duration_ms: 0.69975
      type: 'test'
      ...
    # Subtest: blocks the dynamically loaded futures engine above maxOrderSize
    ok 2 - blocks the dynamically loaded futures engine above maxOrderSize
      ---
      duration_ms: 0.379875
      type: 'test'
      ...
    # Subtest: checks the breaker before attempting market-price discovery
    ok 3 - checks the breaker before attempting market-price discovery
      ---
      duration_ms: 0.199208
      type: 'test'
      ...
    # Subtest: values MEXC contract volume with the venue contract multiplier
    ok 4 - values MEXC contract volume with the venue contract multiplier
      ---
      duration_ms: 1.188583
      type: 'test'
      ...
    1..4
ok 12 - futures pre-trade enforcement
  ---
  duration_ms: 3.019708
  type: 'suite'
  ...
# Subtest: shared pre-trade gate
    # Subtest: blocks every route when the circuit breaker is tripped
    ok 1 - blocks every route when the circuit breaker is tripped
      ---
      duration_ms: 1.271333
      type: 'test'
      ...
    # Subtest: uses the strictest global and caller-specific order cap
    ok 2 - uses the strictest global and caller-specific order cap
      ---
      duration_ms: 0.322791
      type: 'test'
      ...
    # Subtest: fails closed when a route requires a missing notional
    ok 3 - fails closed when a route requires a missing notional
      ---
      duration_ms: 0.311084
      type: 'test'
      ...
    # Subtest: allows risk-reducing exits over the size cap but still honors kill switches
    ok 4 - allows risk-reducing exits over the size cap but still honors kill switches
      ---
      duration_ms: 0.362458
      type: 'test'
      ...
    1..4
ok 13 - shared pre-trade gate
  ---
  duration_ms: 3.43175
  type: 'suite'
  ...
# Subtest: Solana swap notional valuation
    # Subtest: values USDC inputs directly from base units
    ok 1 - values USDC inputs directly from base units
      ---
      duration_ms: 0.843583
      type: 'test'
      ...
    # Subtest: values non-USDC inputs through a Jupiter USDC quote
    ok 2 - values non-USDC inputs through a Jupiter USDC quote
      ---
      duration_ms: 0.208708
      type: 'test'
      ...
    # Subtest: resolves the required input before valuing exact-output swaps
    ok 3 - resolves the required input before valuing exact-output swaps
      ---
      duration_ms: 0.800959
      type: 'test'
      ...
    1..3
ok 14 - Solana swap notional valuation
  ---
  duration_ms: 2.87475
  type: 'suite'
  ...
# Subtest: sentiment analyzer
    # Subtest: scores bullish text positively
    ok 1 - scores bullish text positively
      ---
      duration_ms: 14.921792
      type: 'test'
      ...
    # Subtest: scores bearish text negatively
    ok 2 - scores bearish text negatively
      ---
      duration_ms: 1.992
      type: 'test'
      ...
    # Subtest: handles negation (not bullish → bearish)
    ok 3 - handles negation (not bullish → bearish)
      ---
      duration_ms: 2.504625
      type: 'test'
      ...
    # Subtest: scores Fear & Greed numeric value
    ok 4 - scores Fear & Greed numeric value
      ---
      duration_ms: 1.890416
      type: 'test'
      ...
    # Subtest: scores funding rate as contrarian signal
    ok 5 - scores funding rate as contrarian signal
      ---
      duration_ms: 1.678875
      type: 'test'
      ...
    # Subtest: returns neutral for empty/irrelevant text
    ok 6 - returns neutral for empty/irrelevant text
      ---
      duration_ms: 3.167667
      type: 'test'
      ...
    # Subtest: detects politics category
    ok 7 - detects politics category
      ---
      duration_ms: 1.675791
      type: 'test'
      ...
    # Subtest: detects economics category
    ok 8 - detects economics category
      ---
      duration_ms: 0.998083
      type: 'test'
      ...
    1..8
ok 15 - sentiment analyzer
  ---
  duration_ms: 31.040125
  type: 'suite'
  ...
# Subtest: market matcher
    # Subtest: matches by keyword overlap
    ok 1 - matches by keyword overlap
      ---
      duration_ms: 18.926084
      type: 'test'
      ...
    # Subtest: matches by category
    ok 2 - matches by category
      ---
      duration_ms: 3.054459
      type: 'test'
      ...
    # Subtest: returns empty when no markets loaded
    ok 3 - returns empty when no markets loaded
      ---
      duration_ms: 1.305375
      type: 'test'
      ...
    1..3
ok 16 - market matcher
  ---
  duration_ms: 23.528583
  type: 'suite'
  ...
# Subtest: alt-data service
    # Subtest: processes events through full pipeline
    ok 1 - processes events through full pipeline
      ---
      duration_ms: 7.583708
      type: 'test'
      ...
    # Subtest: getRecentSignals returns empty initially
    ok 2 - getRecentSignals returns empty initially
      ---
      duration_ms: 1.650041
      type: 'test'
      ...
    1..2
ok 17 - alt-data service
  ---
  duration_ms: 9.462917
  type: 'suite'
  ...
# Subtest: fear-greed feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 2.074792
      type: 'test'
      ...
    1..1
ok 18 - fear-greed feed
  ---
  duration_ms: 2.240292
  type: 'suite'
  ...
# Subtest: funding-rates feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 4.324708
      type: 'test'
      ...
    1..1
ok 19 - funding-rates feed
  ---
  duration_ms: 4.511541
  type: 'suite'
  ...
# Subtest: reddit feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 1.9415
      type: 'test'
      ...
    1..1
ok 20 - reddit feed
  ---
  duration_ms: 2.098875
  type: 'suite'
  ...
# Subtest: runtime model defaults do not use retired Anthropic IDs
ok 21 - runtime model defaults do not use retired Anthropic IDs
  ---
  duration_ms: 1.909667
  type: 'test'
  ...
# Subtest: Anthropic provider uses active defaults for completion and health checks
ok 22 - Anthropic provider uses active defaults for completion and health checks
  ---
  duration_ms: 20.230875
  type: 'test'
  ...
# Subtest: backtest engine
    # Subtest: creates engine with all methods
    ok 1 - creates engine with all methods
      ---
      duration_ms: 22.5885
      type: 'test'
      ...
    # Subtest: returns empty result for no ticks
    ok 2 - returns empty result for no ticks
      ---
      duration_ms: 2.39525
      type: 'test'
      ...
    # Subtest: executes buy-and-hold strategy on tick data
    ok 3 - executes buy-and-hold strategy on tick data
      ---
      duration_ms: 2.654375
      type: 'test'
      ...
    # Subtest: handles buy and sell signals correctly
    ok 4 - handles buy and sell signals correctly
      ---
      duration_ms: 1.643667
      type: 'test'
      ...
    # Subtest: respects eval interval
    ok 5 - respects eval interval
      ---
      duration_ms: 2.338833
      type: 'test'
      ...
    # Subtest: applies commission and slippage
    ok 6 - applies commission and slippage
      ---
      duration_ms: 2.251334
      type: 'test'
      ...
    # Subtest: finds orderbook snapshots via binary search
    ok 7 - finds orderbook snapshots via binary search
      ---
      duration_ms: 1.664333
      type: 'test'
      ...
    # Subtest: calls strategy init and cleanup
    ok 8 - calls strategy init and cleanup
      ---
      duration_ms: 1.276333
      type: 'test'
      ...
    1..8
ok 23 - backtest engine
  ---
  duration_ms: 37.9975
  type: 'suite'
  ...
# Subtest: backtest monte carlo
    # Subtest: runs monte carlo simulation
    ok 1 - runs monte carlo simulation
      ---
      duration_ms: 1.145958
      type: 'test'
      ...
    # Subtest: handles empty returns
    ok 2 - handles empty returns
      ---
      duration_ms: 1.969083
      type: 'test'
      ...
    1..2
ok 24 - backtest monte carlo
  ---
  duration_ms: 3.328792
  type: 'suite'
  ...
# Subtest: backtest metrics
    # Subtest: calculates correct metrics for winning trades
    ok 1 - calculates correct metrics for winning trades
      ---
      duration_ms: 3.371958
      type: 'test'
      ...
    1..1
ok 25 - backtest metrics
  ---
  duration_ms: 3.597708
  type: 'suite'
  ...
# Subtest: built-in strategies
    # Subtest: mean reversion strategy has correct config
    ok 1 - mean reversion strategy has correct config
      ---
      duration_ms: 7.398667
      type: 'test'
      ...
    # Subtest: momentum strategy has correct config
    ok 2 - momentum strategy has correct config
      ---
      duration_ms: 3.931083
      type: 'test'
      ...
    # Subtest: strategies accept custom params
    ok 3 - strategies accept custom params
      ---
      duration_ms: 4.157167
      type: 'test'
      ...
    1..3
ok 26 - built-in strategies
  ---
  duration_ms: 15.713958
  type: 'suite'
  ...
# Subtest: bittensor wallet
    # Subtest: raoToTao converts 1 billion rao to 1 TAO
    ok 1 - raoToTao converts 1 billion rao to 1 TAO
      ---
      duration_ms: 0.352916
      type: 'test'
      ...
    1..1
ok 27 - bittensor wallet
  ---
  duration_ms: 0.7655
  type: 'suite'
  ...
# Subtest: bittensor python-runner
    # Subtest: sanitizeArg strips dangerous shell characters
    ok 1 - sanitizeArg strips dangerous shell characters
      ---
      duration_ms: 30.798792
      type: 'test'
      ...
    # Subtest: createPythonRunner returns object with exec, spawn, btcli
    ok 2 - createPythonRunner returns object with exec, spawn, btcli
      ---
      duration_ms: 9.049125
      type: 'test'
      ...
    1..2
ok 28 - bittensor python-runner
  ---
  duration_ms: 40.041208
  type: 'suite'
  ...
# Subtest: bittensor chutes manager
    # Subtest: initializes with GPU nodes from config
    ok 1 - initializes with GPU nodes from config
      ---
      duration_ms: 9.902375
      type: 'test'
      ...
    # Subtest: addGpuNode and removeGpuNode work correctly
    ok 2 - addGpuNode and removeGpuNode work correctly
      ---
      duration_ms: 1.267
      type: 'test'
      ...
    # Subtest: getInvocationStats returns zero when not started
    ok 3 - getInvocationStats returns zero when not started
      ---
      duration_ms: 1.163292
      type: 'test'
      ...
    1..3
ok 29 - bittensor chutes manager
  ---
  duration_ms: 13.405458
  type: 'suite'
  ...
# Subtest: bittensor persistence
    # Subtest: init creates all three tables
    ok 1 - init creates all three tables
      ---
      duration_ms: 5.576959
      type: 'test'
      ...
    # Subtest: saveEarnings and getEarnings round-trip
    ok 2 - saveEarnings and getEarnings round-trip
      ---
      duration_ms: 2.098708
      type: 'test'
      ...
    # Subtest: saveMinerStatus and getMinerStatus round-trip
    ok 3 - saveMinerStatus and getMinerStatus round-trip
      ---
      duration_ms: 1.817625
      type: 'test'
      ...
    # Subtest: saveMinerStatus upserts on conflict
    ok 4 - saveMinerStatus upserts on conflict
      ---
      duration_ms: 3.157458
      type: 'test'
      ...
    # Subtest: getMinerStatuses returns all rows
    ok 5 - getMinerStatuses returns all rows
      ---
      duration_ms: 1.757416
      type: 'test'
      ...
    # Subtest: logCost and getCosts round-trip
    ok 6 - logCost and getCosts round-trip
      ---
      duration_ms: 2.521792
      type: 'test'
      ...
    # Subtest: getMinerStatus returns null for missing entry
    ok 7 - getMinerStatus returns null for missing entry
      ---
      duration_ms: 1.14575
      type: 'test'
      ...
    1..7
ok 30 - bittensor persistence
  ---
  duration_ms: 18.727167
  type: 'suite'
  ...
# Subtest: bittensor handler
    # Subtest: returns error when service is not set
    ok 1 - returns error when service is not set
      ---
      duration_ms: 29.325709
      type: 'test'
      ...
    # Subtest: returns status when service is set
    ok 2 - returns status when service is set
      ---
      duration_ms: 13.19375
      type: 'test'
      ...
    # Subtest: returns earnings for a period
    ok 3 - returns earnings for a period
      ---
      duration_ms: 10.140209
      type: 'test'
      ...
    # Subtest: returns error for unknown action
    ok 4 - returns error for unknown action
      ---
      duration_ms: 4.272084
      type: 'test'
      ...
    # Subtest: requires subnetId for start/stop/register
    ok 5 - requires subnetId for start/stop/register
      ---
      duration_ms: 13.658083
      type: 'test'
      ...
    1..5
ok 31 - bittensor handler
  ---
  duration_ms: 70.888875
  type: 'suite'
  ...
# Subtest: bittensor router
    # Subtest: creates a router with all expected routes
    ok 1 - creates a router with all expected routes
      ---
      duration_ms: 123.268834
      type: 'test'
      ...
    1..1
ok 32 - bittensor router
  ---
  duration_ms: 123.370959
  type: 'suite'
  ...
# Subtest: BotManager
    # Subtest: creates bot manager with default config
    ok 1 - creates bot manager with default config
      ---
      duration_ms: 50.195917
      type: 'test'
      ...
    # Subtest: registers and lists strategies
    ok 2 - registers and lists strategies
      ---
      duration_ms: 8.85475
      type: 'test'
      ...
    # Subtest: getStrategy returns Strategy by ID
    ok 3 - getStrategy returns Strategy by ID
      ---
      duration_ms: 10.941375
      type: 'test'
      ...
    # Subtest: getStrategy returns null for unknown ID
    ok 4 - getStrategy returns null for unknown ID
      ---
      duration_ms: 33.60675
      type: 'test'
      ...
    # Subtest: returns bot statuses
    ok 5 - returns bot statuses
      ---
      duration_ms: 11.3815
      type: 'test'
      ...
    # Subtest: getTradeLogger returns a logger instance
    ok 6 - getTradeLogger returns a logger instance
      ---
      duration_ms: 11.142458
      type: 'test'
      ...
    1..6
ok 33 - BotManager
  ---
  duration_ms: 130.154083
  type: 'suite'
  ...
# Subtest: BotManager with shared TradeLogger
    # Subtest: uses external tradeLogger when provided
    ok 1 - uses external tradeLogger when provided
      ---
      duration_ms: 9.274916
      type: 'test'
      ...
    # Subtest: creates own tradeLogger when not provided
    ok 2 - creates own tradeLogger when not provided
      ---
      duration_ms: 3.236208
      type: 'test'
      ...
    1..2
ok 34 - BotManager with shared TradeLogger
  ---
  duration_ms: 13.87125
  type: 'suite'
  ...
# Subtest: BotManager with execution callbacks
    # Subtest: accepts executeOrder callback
    ok 1 - accepts executeOrder callback
      ---
      duration_ms: 3.503084
      type: 'test'
      ...
    # Subtest: accepts getPrice callback
    ok 2 - accepts getPrice callback
      ---
      duration_ms: 6.791583
      type: 'test'
      ...
    # Subtest: accepts getMarket callback
    ok 3 - accepts getMarket callback
      ---
      duration_ms: 2.781417
      type: 'test'
      ...
    # Subtest: accepts getPortfolio callback
    ok 4 - accepts getPortfolio callback
      ---
      duration_ms: 5.125
      type: 'test'
      ...
    1..4
ok 35 - BotManager with execution callbacks
  ---
  duration_ms: 18.496875
  type: 'suite'
  ...
# Subtest: StrategyBuilder
    # Subtest: creates strategy builder
    ok 1 - creates strategy builder
      ---
      duration_ms: 5.442208
      type: 'test'
      ...
    # Subtest: lists available templates
    ok 2 - lists available templates
      ---
      duration_ms: 1.414292
      type: 'test'
      ...
    # Subtest: validates a strategy definition
    ok 3 - validates a strategy definition
      ---
      duration_ms: 2.85125
      type: 'test'
      ...
    1..3
ok 36 - StrategyBuilder
  ---
  duration_ms: 9.946041
  type: 'suite'
  ...
# Subtest: Trading Adapters
    # Subtest: creates crypto HFT adapter as Strategy
    ok 1 - creates crypto HFT adapter as Strategy
      ---
      duration_ms: 7.854167
      type: 'test'
      ...
    # Subtest: creates divergence adapter as Strategy
    ok 2 - creates divergence adapter as Strategy
      ---
      duration_ms: 1.148
      type: 'test'
      ...
    # Subtest: crypto HFT adapter evaluate returns empty when engine not started
    ok 3 - crypto HFT adapter evaluate returns empty when engine not started
      ---
      duration_ms: 0.907875
      type: 'test'
      ...
    # Subtest: divergence adapter evaluate returns empty when engine not started
    ok 4 - divergence adapter evaluate returns empty when engine not started
      ---
      duration_ms: 0.685916
      type: 'test'
      ...
    # Subtest: adapters can be registered in BotManager
    ok 5 - adapters can be registered in BotManager
      ---
      duration_ms: 1.305917
      type: 'test'
      ...
    1..5
ok 37 - Trading Adapters
  ---
  duration_ms: 12.233
  type: 'suite'
  ...
# Subtest: Config env var overrides
    # Subtest: maps Discord credentials into the runtime channel config
    ok 1 - maps Discord credentials into the runtime channel config
      ---
      duration_ms: 18.124875
      type: 'test'
      ...
    # Subtest: MARKET_MAKING_ENABLED sets config.trading.marketMaking.enabled
    ok 2 - MARKET_MAKING_ENABLED sets config.trading.marketMaking.enabled
      ---
      duration_ms: 18.2615
      type: 'test'
      ...
    # Subtest: CRYPTO_HFT_ENABLED sets config.trading.cryptoHft.enabled
    ok 3 - CRYPTO_HFT_ENABLED sets config.trading.cryptoHft.enabled
      ---
      duration_ms: 2.886708
      type: 'test'
      ...
    # Subtest: HFT_DIVERGENCE_ENABLED sets config.trading.hftDivergence.enabled
    ok 4 - HFT_DIVERGENCE_ENABLED sets config.trading.hftDivergence.enabled
      ---
      duration_ms: 3.155125
      type: 'test'
      ...
    1..4
ok 38 - Config env var overrides
  ---
  duration_ms: 42.742041
  type: 'suite'
  ...
# [2026-09-12 04:00:47.683 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# Subtest: risk command parses settings and updates user
ok 39 - risk command parses settings and updates user
  ---
  duration_ms: 2.043292
  type: 'test'
  ...
# Subtest: risk command rejects invalid input
ok 40 - risk command rejects invalid input
  ---
  duration_ms: 0.115
  type: 'test'
  ...
# Subtest: digest command parses time and enables
ok 41 - digest command parses time and enables
  ---
  duration_ms: 0.18625
  type: 'test'
  ...
# Subtest: compare command parses platforms and limit
ok 42 - compare command parses platforms and limit
  ---
  duration_ms: 28.483833
  type: 'test'
  ...
# Subtest: markets command errors on empty args
ok 43 - markets command errors on empty args
  ---
  duration_ms: 0.906584
  type: 'test'
  ...
# Subtest: markets command treats single token as query
ok 44 - markets command treats single token as query
  ---
  duration_ms: 0.353333
  type: 'test'
  ...
# Subtest: arbitrage command parses args and uses minEdge
ok 45 - arbitrage command parses args and uses minEdge
  ---
  duration_ms: 0.8295
  type: 'test'
  ...
# Subtest: pnl command parses args and passes since/limit to db
ok 46 - pnl command parses args and passes since/limit to db
  ---
  duration_ms: 0.644834
  type: 'test'
  ...
# Subtest: resolveStateDir uses override
ok 47 - resolveStateDir uses override
  ---
  duration_ms: 1.013542
  type: 'test'
  ...
# Subtest: resolveConfigPath uses override
ok 48 - resolveConfigPath uses override
  ---
  duration_ms: 0.168834
  type: 'test'
  ...
# Subtest: resolveWorkspaceDir uses override
ok 49 - resolveWorkspaceDir uses override
  ---
  duration_ms: 0.163041
  type: 'test'
  ...
# Subtest: fast-broadcast byte parity with ethers wallet.sendTransaction
    # Subtest: produces the exact same signed raw transaction bytes as the native ethers path
    ok 1 - produces the exact same signed raw transaction bytes as the native ethers path
      ---
      duration_ms: 177.926875
      type: 'test'
      ...
    1..1
ok 50 - fast-broadcast byte parity with ethers wallet.sendTransaction
  ---
  duration_ms: 178.656583
  type: 'suite'
  ...
# Subtest: fast-broadcast (Rust worker via TS wrapper)
ok 51 - fast-broadcast (Rust worker via TS wrapper) # SKIP fast-broadcast Rust binary not built — run `cargo build` in rust/fast-broadcast/
  ---
  duration_ms: 0.21825
  type: 'suite'
  ...
# Subtest: market index search boosts text matches
ok 52 - market index search boosts text matches
  ---
  duration_ms: 1.018708
  type: 'test'
  ...
# Subtest: market index search applies platform weights
ok 53 - market index search applies platform weights
  ---
  duration_ms: 0.709792
  type: 'test'
  ...
# Subtest: market index search honors minScore
ok 54 - market index search honors minScore
  ---
  duration_ms: 0.496166
  type: 'test'
  ...
# Subtest: ml-pipeline types
    # Subtest: exports default quality gates
    ok 1 - exports default quality gates
      ---
      duration_ms: 8.457417
      type: 'test'
      ...
    1..1
ok 55 - ml-pipeline types
  ---
  duration_ms: 9.294542
  type: 'suite'
  ...
# Subtest: combinedToMarketFeatures
    # Subtest: handles null combined features
    ok 1 - handles null combined features
      ---
      duration_ms: 13.814292
      type: 'test'
      ...
    # Subtest: maps tick features correctly
    ok 2 - maps tick features correctly
      ---
      duration_ms: 1.384334
      type: 'test'
      ...
    # Subtest: maps orderbook features correctly
    ok 3 - maps orderbook features correctly
      ---
      duration_ms: 1.379625
      type: 'test'
      ...
    1..3
ok 56 - combinedToMarketFeatures
  ---
  duration_ms: 18.186875
  type: 'suite'
  ...
# Subtest: ml collector
    # Subtest: creates ml_training_samples table on init
    ok 1 - creates ml_training_samples table on init
      ---
      duration_ms: 6.699542
      type: 'test'
      ...
    # Subtest: captures signal on executed event
    ok 2 - captures signal on executed event
      ---
      duration_ms: 2.154
      type: 'test'
      ...
    # Subtest: captures signal on dry_run event
    ok 3 - captures signal on dry_run event
      ---
      duration_ms: 1.765541
      type: 'test'
      ...
    # Subtest: returns sample counts
    ok 4 - returns sample counts
      ---
      duration_ms: 1.336834
      type: 'test'
      ...
    # Subtest: stops cleanly
    ok 5 - stops cleanly
      ---
      duration_ms: 3.078458
      type: 'test'
      ...
    1..5
ok 57 - ml collector
  ---
  duration_ms: 15.815625
  type: 'suite'
  ...
# Subtest: ml trainer
    # Subtest: creates trainer with stats
    ok 1 - creates trainer with stats
      ---
      duration_ms: 3.210083
      type: 'test'
      ...
    # Subtest: skips training with too few samples
    ok 2 - skips training with too few samples
      ---
      duration_ms: 1.665958
      type: 'test'
      ...
    # Subtest: starts and stops cleanly
    ok 3 - starts and stops cleanly
      ---
      duration_ms: 1.489833
      type: 'test'
      ...
    1..3
ok 58 - ml trainer
  ---
  duration_ms: 6.593125
  type: 'suite'
  ...
# Subtest: ml pipeline factory
    # Subtest: creates pipeline with model
    ok 1 - creates pipeline with model
      ---
      duration_ms: 7.007791
      type: 'test'
      ...
    # Subtest: returns stats
    ok 2 - returns stats
      ---
      duration_ms: 2.218834
      type: 'test'
      ...
    # Subtest: starts and stops with signal router
    ok 3 - starts and stops with signal router
      ---
      duration_ms: 8.027417
      type: 'test'
      ...
    1..3
ok 59 - ml pipeline factory
  ---
  duration_ms: 17.483708
  type: 'suite'
  ...
# Subtest: signal router with ML model
    # Subtest: accepts optional mlModel parameter
    ok 1 - accepts optional mlModel parameter
      ---
      duration_ms: 21.450125
      type: 'test'
      ...
    # Subtest: works without mlModel (backward compatible)
    ok 2 - works without mlModel (backward compatible)
      ---
      duration_ms: 1.541791
      type: 'test'
      ...
    1..2
ok 60 - signal router with ML model
  ---
  duration_ms: 23.191666
  type: 'suite'
  ...
# Subtest: multi-hop arbitrage planner
    # Subtest: finds a profitable three-hop cycle
    ok 1 - finds a profitable three-hop cycle
      ---
      duration_ms: 0.97025
      type: 'test'
      ...
    # Subtest: marks all-solana paths as atomic bundles when every hop is bundle-eligible
    ok 2 - marks all-solana paths as atomic bundles when every hop is bundle-eligible
      ---
      duration_ms: 0.252208
      type: 'test'
      ...
    # Subtest: marks all-evm paths as exact-in for deterministic entry sizing
    ok 3 - marks all-evm paths as exact-in for deterministic entry sizing
      ---
      duration_ms: 0.210917
      type: 'test'
      ...
    1..3
ok 61 - multi-hop arbitrage planner
  ---
  duration_ms: 2.417334
  type: 'suite'
  ...
# Subtest: multichain getRaceUrls
    # Subtest: defaults to just the primary RPC when no fallbacks are configured
    ok 1 - defaults to just the primary RPC when no fallbacks are configured
      ---
      duration_ms: 586.919625
      type: 'test'
      ...
    # Subtest: includes configured fallbacks after the primary, trimmed
    ok 2 - includes configured fallbacks after the primary, trimmed
      ---
      duration_ms: 396.357416
      type: 'test'
      ...
    # Subtest: dedupes a fallback that matches the primary
    ok 3 - dedupes a fallback that matches the primary
      ---
      duration_ms: 335.241709
      type: 'test'
      ...
    1..3
ok 62 - multichain getRaceUrls
  ---
  duration_ms: 1319.0305
  type: 'suite'
  ...
# Subtest: opportunity hft integration
    # Subtest: builds a live venue plan from an opportunity and uses outcome token ids for polymarket
    ok 1 - builds a live venue plan from an opportunity and uses outcome token ids for polymarket
      ---
      duration_ms: 2.584459
      type: 'test'
      ...
    # Subtest: builds live linked-market venue plans from market identity groups
    ok 2 - builds live linked-market venue plans from market identity groups
      ---
      duration_ms: 0.673042
      type: 'test'
      ...
    # Subtest: derives NO-side pricing from binary yes orderbooks when venue lookup is market-level only
    ok 3 - derives NO-side pricing from binary yes orderbooks when venue lookup is market-level only
      ---
      duration_ms: 1.303167
      type: 'test'
      ...
    1..3
ok 63 - opportunity hft integration
  ---
  duration_ms: 5.739459
  type: 'suite'
  ...
# Subtest: Polymarket V2 order signer byte parity with ethers EIP-712
    # Subtest: produces a byte-identical signature to an independent ethers reference (standard exchange, BUY)
    ok 1 - produces a byte-identical signature to an independent ethers reference (standard exchange, BUY)
      ---
      duration_ms: 85.330208
      type: 'test'
      ...
    # Subtest: produces a byte-identical signature to an independent ethers reference (negRisk exchange, SELL)
    ok 2 - produces a byte-identical signature to an independent ethers reference (negRisk exchange, SELL)
      ---
      duration_ms: 14.631875
      type: 'test'
      ...
    # Subtest: defaults metadata/builder to 32 zero bytes and rejects POLY_1271
    ok 3 - defaults metadata/builder to 32 zero bytes and rejects POLY_1271
      ---
      duration_ms: 2.501709
      type: 'test'
      ...
    1..3
ok 64 - Polymarket V2 order signer byte parity with ethers EIP-712
  ---
  duration_ms: 103.003542
  type: 'suite'
  ...
# Subtest: enforceMaxOrderSize blocks oversized order
ok 65 - enforceMaxOrderSize blocks oversized order
  ---
  duration_ms: 0.511625
  type: 'test'
  ...
# Subtest: enforceMaxOrderSize allows small or invalid notional
ok 66 - enforceMaxOrderSize allows small or invalid notional
  ---
  duration_ms: 0.065333
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks maxTotalExposure
ok 67 - enforceExposureLimits blocks maxTotalExposure
  ---
  duration_ms: 0.169917
  type: 'test'
  ...
# Subtest: enforceExposureLimits ignores non-positive notional
ok 68 - enforceExposureLimits ignores non-positive notional
  ---
  duration_ms: 0.05575
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks maxPositionValue
ok 69 - enforceExposureLimits blocks maxPositionValue
  ---
  duration_ms: 0.125375
  type: 'test'
  ...
# Subtest: enforceExposureLimits skips maxPositionValue when market/outcome missing
ok 70 - enforceExposureLimits skips maxPositionValue when market/outcome missing
  ---
  duration_ms: 0.059625
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks stop-loss threshold
ok 71 - enforceExposureLimits blocks stop-loss threshold
  ---
  duration_ms: 0.074708
  type: 'test'
  ...
# Subtest: enforceExposureLimits returns null when no limits configured
ok 72 - enforceExposureLimits returns null when no limits configured
  ---
  duration_ms: 0.0885
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage report summarizes reuse targets
ok 73 - rust-hft-arbitrage report summarizes reuse targets
  ---
  duration_ms: 0.4875
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage venues command lists concrete venues
ok 74 - rust-hft-arbitrage venues command lists concrete venues
  ---
  duration_ms: 0.099792
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan help shows usage without hitting the network
ok 75 - rust-hft-arbitrage scan help shows usage without hitting the network
  ---
  duration_ms: 0.1255
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan rejects an unknown family before scanning
ok 76 - rust-hft-arbitrage scan rejects an unknown family before scanning
  ---
  duration_ms: 0.116792
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan requires size and tokens
ok 77 - rust-hft-arbitrage scan requires size and tokens
  ---
  duration_ms: 0.047541
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan requires a valid chain for evm/cross families
ok 78 - rust-hft-arbitrage scan requires a valid chain for evm/cross families
  ---
  duration_ms: 0.066
  type: 'test'
  ...
# Subtest: signal router
    # Subtest: creates with start/stop lifecycle
    ok 1 - creates with start/stop lifecycle
      ---
      duration_ms: 29.551834
      type: 'test'
      ...
    # Subtest: rejects signals below min strength
    ok 2 - rejects signals below min strength
      ---
      duration_ms: 53.550416
      type: 'test'
      ...
    # Subtest: rejects neutral direction signals
    ok 3 - rejects neutral direction signals
      ---
      duration_ms: 53.780291
      type: 'test'
      ...
    # Subtest: filters by signal type
    ok 4 - filters by signal type
      ---
      duration_ms: 56.224167
      type: 'test'
      ...
    # Subtest: filters by platform
    ok 5 - filters by platform
      ---
      duration_ms: 56.672041
      type: 'test'
      ...
    # Subtest: enforces per-market cooldown
    ok 6 - enforces per-market cooldown
      ---
      duration_ms: 103.992834
      type: 'test'
      ...
    # Subtest: rejects when no price data available
    ok 7 - rejects when no price data available
      ---
      duration_ms: 54.40175
      type: 'test'
      ...
    # Subtest: tracks recent executions
    ok 8 - tracks recent executions
      ---
      duration_ms: 51.876041
      type: 'test'
      ...
    # Subtest: respects daily loss limit
    ok 9 - respects daily loss limit
      ---
      duration_ms: 52.556833
      type: 'test'
      ...
    # Subtest: enforces max concurrent positions
    ok 10 - enforces max concurrent positions
      ---
      duration_ms: 51.834334
      type: 'test'
      ...
    # Subtest: updateConfig changes behavior
    ok 11 - updateConfig changes behavior
      ---
      duration_ms: 0.451708
      type: 'test'
      ...
    # Subtest: resetDailyStats clears counters
    ok 12 - resetDailyStats clears counters
      ---
      duration_ms: 52.114833
      type: 'test'
      ...
    1..12
ok 79 - signal router
  ---
  duration_ms: 618.334
  type: 'suite'
  ...
# Subtest: computeWeightedAverageFill
    # Subtest: fills fully within a single level
    ok 1 - fills fully within a single level
      ---
      duration_ms: 0.396291
      type: 'test'
      ...
    # Subtest: walks multiple levels and reports partial fills when depth runs out
    ok 2 - walks multiple levels and reports partial fills when depth runs out
      ---
      duration_ms: 0.102708
      type: 'test'
      ...
    # Subtest: returns null for empty or invalid book depth
    ok 3 - returns null for empty or invalid book depth
      ---
      duration_ms: 0.045666
      type: 'test'
      ...
    1..3
ok 80 - computeWeightedAverageFill
  ---
  duration_ms: 0.938083
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (solana)
    # Subtest: finds a crossed plan between two solana venues and prices it sanely
    ok 1 - finds a crossed plan between two solana venues and prices it sanely
      ---
      duration_ms: 12.261875
      type: 'test'
      ...
    # Subtest: picks pumpswap as the cheapest venue among three solana AMMs
    ok 2 - picks pumpswap as the cheapest venue among three solana AMMs
      ---
      duration_ms: 0.870166
      type: 'test'
      ...
    # Subtest: routes a failing venue into skipped without dropping the rest
    ok 3 - routes a failing venue into skipped without dropping the rest
      ---
      duration_ms: 0.2935
      type: 'test'
      ...
    1..3
ok 81 - scanVenueArbitrage (solana)
  ---
  duration_ms: 13.589041
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (evm)
    # Subtest: finds a crossed plan between uniswap and lighter on arbitrum
    ok 1 - finds a crossed plan between uniswap and lighter on arbitrum
      ---
      duration_ms: 0.621959
      type: 'test'
      ...
    # Subtest: rejects lighter quoting outside arbitrum
    ok 2 - rejects lighter quoting outside arbitrum
      ---
      duration_ms: 0.08825
      type: 'test'
      ...
    1..2
ok 82 - scanVenueArbitrage (evm)
  ---
  duration_ms: 0.89325
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (cross-chain)
    # Subtest: combines solana and evm legs and flags the pre-positioned inventory assumption
    ok 1 - combines solana and evm legs and flags the pre-positioned inventory assumption
      ---
      duration_ms: 0.427792
      type: 'test'
      ...
    1..1
ok 83 - scanVenueArbitrage (cross-chain)
  ---
  duration_ms: 0.546708
  type: 'suite'
  ...
# Subtest: venue arbitrage planner
    # Subtest: finds a net-positive crossed venue arbitrage plan
    ok 1 - finds a net-positive crossed venue arbitrage plan
      ---
      duration_ms: 1.593792
      type: 'test'
      ...
    # Subtest: drops stale quotes before planning
    ok 2 - drops stale quotes before planning
      ---
      duration_ms: 0.091417
      type: 'test'
      ...
    # Subtest: penalizes slower venues enough to prefer the faster route
    ok 3 - penalizes slower venues enough to prefer the faster route
      ---
      duration_ms: 0.249125
      type: 'test'
      ...
    # Subtest: supports maker-taker execution sequencing
    ok 4 - supports maker-taker execution sequencing
      ---
      duration_ms: 0.124875
      type: 'test'
      ...
    # Subtest: can surface queue-based maker opportunities when crossed-market mode is disabled
    ok 5 - can surface queue-based maker opportunities when crossed-market mode is disabled
      ---
      duration_ms: 0.14325
      type: 'test'
      ...
    # Subtest: accepts Solana and EVM venue identifiers in the planner
    ok 6 - accepts Solana and EVM venue identifiers in the planner
      ---
      duration_ms: 0.155167
      type: 'test'
      ...
    1..6
ok 84 - venue arbitrage planner
  ---
  duration_ms: 3.218042
  type: 'suite'
  ...
# Subtest: webhook manager rejects invalid signature
ok 85 - webhook manager rejects invalid signature
  ---
  duration_ms: 1.287667
  type: 'test'
  ...
# Subtest: webhook manager enforces rate limit
ok 86 - webhook manager enforces rate limit
  ---
  duration_ms: 0.31075
  type: 'test'
  ...
1..86
# tests 186
# suites 44
# pass 186
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 4729.896167

> clodds@1.9.0 build
> tsc && node -e "const{cpSync,readdirSync}=require('fs'),p=require('path');readdirSync('src/skills/bundled',{withFileTypes:true}).filter(d=>d.isDirectory()).forEach(d=>{const s=p.join('src/skills/bundled',d.name,'SKILL.md'),t=p.join('dist/skills/bundled',d.name,'SKILL.md');try{cpSync(s,t)}catch{}})"\n- 186 tests passed\n- TypeScript typecheck passed\n- production build passed