### PR TITLE
fix: trigger bracket stops off book

### DIFF
--- a/src/execution/bracket-orders.ts
+++ b/src/execution/bracket-orders.ts
@@ -2,8 +2,8 @@
  * OCO Bracket Orders - One-Cancels-Other stop-loss + take-profit pairs
  *
  * Features:
- * - Pairs a take-profit limit with a stop-loss limit
- * - When one fills, automatically cancels the other
+ * - Pairs a take-profit limit with a monitored stop-loss trigger
+ * - Cancels the take-profit before executing a triggered market exit
  * - Supports Polymarket and Kalshi
  * - Polling-based fill detection
  * - Database persistence (survives restarts)
@@ -63,9 +63,9 @@ export interface BracketStatus {
 export interface BracketOrder extends EventEmitter {
   /** Unique order ID */
   id: string;
-  /** Place both orders and begin monitoring */
+  /** Place the take-profit and begin monitoring the stop trigger */
   start(): Promise<void>;
-  /** Cancel both orders */
+  /** Cancel the resting take-profit and stop monitoring */
   cancel(): Promise<void>;
   /** Get current bracket status */
   getStatus(): BracketStatus;
@@ -165,17 +165,6 @@ export function createBracketOrder(
   }
 
   /**
-   * Place the stop-loss order
-   */
-  async function placeStopLoss(): Promise<OrderResult> {
-    return executionService.sellLimit({
-      ...buildBaseOrder(),
-      price: config.stopLossPrice,
-      size: config.size,
-    });
-  }
-
-  /**
    * Check if an order has filled
    * Returns { filled, price, missing } where missing=true means the order no longer exists on the exchange
    */
@@ -223,7 +212,7 @@ export function createBracketOrder(
 
     // Track whether each order is missing from the exchange for resolution detection
     let tpMissing = !takeProfitOrderId; // If no TP order ID, treat as missing
-    let slMissing = !stopLossOrderId;   // If no SL order ID, treat as missing
+    let slMissing = !stopLossOrderId;   // Legacy resting stop orders only
 
     // Check take-profit
     if (takeProfitOrderId) {
@@ -262,7 +251,85 @@ export function createBracketOrder(
       tpMissing = tp.missing === true;
     }
 
-    // Check stop-loss
+    // New brackets keep the stop off-book. A sell limit below the market is
+    // marketable, not a stop, so wait until the executable bid crosses the
+    // threshold and only then submit the exit.
+    if (!stopLossOrderId) {
+      const marketKey = config.platform === 'polymarket'
+        ? config.tokenId
+        : config.marketId;
+      if (!marketKey) {
+        logger.error({ orderId }, 'Bracket: cannot monitor stop-loss without a market identifier');
+      } else {
+        const marketPrice = await executionService.getExecutablePrice(
+          config.platform,
+          marketKey,
+          'sell',
+          config.outcome
+        );
+
+        if (marketPrice !== null && marketPrice <= config.stopLossPrice) {
+          logger.warn(
+            { orderId, marketPrice, stopLossPrice: config.stopLossPrice },
+            'Bracket: stop-loss threshold crossed'
+          );
+
+          // The take-profit can reserve the same shares. Do not submit the stop
+          // exit unless that resting order was definitely cancelled first.
+          if (takeProfitOrderId) {
+            const cancelled = await executionService.cancelOrder(config.platform, takeProfitOrderId);
+            if (!cancelled) {
+              logger.error(
+                { orderId, takeProfitOrderId },
+                'Bracket: stop-loss delayed because take-profit cancellation was not confirmed'
+              );
+              return;
+            }
+            takeProfitOrderId = undefined;
+          }
+
+          const result = await executionService.marketSell({
+            ...buildBaseOrder(),
+            size: config.size,
+          });
+          if (!result.success) {
+            status = 'failed';
+            cleanup();
+            try {
+              updateBracketStatus(orderId, { status: 'failed' });
+            } catch (err) {
+              logger.warn({ error: String(err) }, 'Failed to persist bracket stop-loss failure');
+            }
+            emitter.emit('failed', { error: `Stop-loss execution failed: ${result.error}` });
+            return;
+          }
+
+          stopLossOrderId = result.orderId;
+          status = 'stop_loss_hit';
+          filledSide = 'stop_loss';
+          fillPrice = result.avgFillPrice ?? marketPrice;
+          cleanup();
+          try {
+            updateBracketStatus(orderId, {
+              stopLossOrderId,
+              status: 'stop_loss_hit',
+              filledSide: 'stop_loss',
+              fillPrice,
+            });
+          } catch (err) {
+            logger.warn({ error: String(err) }, 'Failed to persist bracket SL hit');
+          }
+          emitter.emit('stop_loss_hit', {
+            orderId: stopLossOrderId,
+            fillPrice,
+            status: getStatusSnapshot(),
+          });
+          return;
+        }
+      }
+    }
+
+    // Check legacy stop-loss orders created by older versions.
     if (stopLossOrderId) {
       const sl = await checkOrderFilled(stopLossOrderId);
       if (sl.filled) {
@@ -390,11 +457,11 @@ export function createBracketOrder(
         sl: config.stopLossPrice,
         size: config.size,
       },
-      'Bracket order: placing TP + SL'
+      'Bracket order: placing TP + monitored SL'
     );
 
-    // Place TP first, then SL. If SL fails after TP succeeds, cancel TP to
-    // avoid leaving the user without stop-loss protection.
+    // The take-profit rests on the book. The stop-loss remains an off-book
+    // trigger and is submitted only after the monitored bid crosses it.
     try {
       const tpResult = await placeTakeProfit();
       if (tpResult.success) {
@@ -419,51 +486,6 @@ export function createBracketOrder(
         logger.warn({ error: String(persistErr) }, 'Failed to persist bracket failure');
       }
       emitter.emit('failed', { error: `Take-profit placement threw: ${String(err)}` });
-      return;
-    }
-
-    try {
-      const slResult = await placeStopLoss();
-      if (slResult.success) {
-        stopLossOrderId = slResult.orderId;
-      } else {
-        logger.error({ error: slResult.error }, 'Bracket: failed to place stop-loss');
-        // Cancel the TP since SL failed -- user would have no stop-loss protection
-        if (takeProfitOrderId) {
-          try {
-            await executionService.cancelOrder(config.platform, takeProfitOrderId);
-            logger.info({ orderId: takeProfitOrderId }, 'Bracket: cancelled TP after SL failure');
-          } catch (cancelErr) {
-            logger.warn({ error: String(cancelErr) }, 'Bracket: failed to cancel TP after SL failure');
-          }
-        }
-        status = 'failed';
-        try {
-          updateBracketStatus(orderId, { status: 'failed' });
-        } catch (persistErr) {
-          logger.warn({ error: String(persistErr) }, 'Failed to persist bracket failure');
-        }
-        emitter.emit('failed', { error: `Stop-loss placement failed: ${slResult.error}` });
-        return;
-      }
-    } catch (err) {
-      logger.error({ error: String(err) }, 'Bracket: stop-loss placement threw');
-      // Cancel the TP since SL failed
-      if (takeProfitOrderId) {
-        try {
-          await executionService.cancelOrder(config.platform, takeProfitOrderId);
-          logger.info({ orderId: takeProfitOrderId }, 'Bracket: cancelled TP after SL throw');
-        } catch (cancelErr) {
-          logger.warn({ error: String(cancelErr) }, 'Bracket: failed to cancel TP after SL throw');
-        }
-      }
-      status = 'failed';
-      try {
-        updateBracketStatus(orderId, { status: 'failed' });
-      } catch (persistErr) {
-        logger.warn({ error: String(persistErr) }, 'Failed to persist bracket failure');
-      }
-      emitter.emit('failed', { error: `Stop-loss placement threw: ${String(err)}` });
       return;
     }
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -270,6 +270,14 @@ export interface ExecutionService {
   /** Fetch orderbooks for multiple tokens in one call */
   getOrderbooksBatch(tokenIds: string[]): Promise<Map<string, OrderbookData | null>>;
 
+  /** Fetch the executable market price for trigger-based orders. */
+  getExecutablePrice(
+    platform: 'polymarket' | 'kalshi',
+    marketIdOrTokenId: string,
+    side: 'buy' | 'sell',
+    outcome?: string
+  ): Promise<number | null>;
+
   // Circuit Breaker Integration
   /** Enable circuit breaker for order validation (blocks orders when tripped) */
   setCircuitBreaker(breaker: import('./circuit-breaker').CircuitBreaker | null): void;
@@ -3688,6 +3696,29 @@ export function createExecutionService(config: ExecutionConfig): ExecutionServic
 
     async getOrderbooksBatch(tokenIds: string[]) {
       return getPolymarketOrderbooksBatch(tokenIds);
+    },
+
+    async getExecutablePrice(platform, marketIdOrTokenId, side, outcome) {
+      const orderbook = platform === 'polymarket'
+        ? await fetchPolymarketOrderbook(marketIdOrTokenId)
+        : await fetchKalshiOrderbook(marketIdOrTokenId);
+      if (!orderbook) return null;
+
+      // A sell stop is triggered by the price it can actually sell at (best bid),
+      // while a buy trigger uses the best ask. Mid-price can falsely indicate that
+      // an illiquid stop is still safe.
+      let price: number | undefined;
+      if (platform === 'kalshi' && outcome?.toLowerCase() === 'no') {
+        // Kalshi orderbooks are normalized above to the YES perspective.
+        price = side === 'sell'
+          ? 1 - (orderbook.asks[0]?.[0] ?? 1)
+          : 1 - (orderbook.bids[0]?.[0] ?? 0);
+      } else {
+        price = side === 'sell'
+          ? orderbook.bids[0]?.[0]
+          : orderbook.asks[0]?.[0];
+      }
+      return price !== undefined && Number.isFinite(price) && price > 0 ? price : null;
     },
 
     // =========================================================================

--- a/src/trading/index.ts
+++ b/src/trading/index.ts
@@ -414,6 +414,7 @@ function wrapExecutionWithLogging(
     getUSDCAllowance: execution.getUSDCAllowance.bind(execution),
     // Batch orderbook fetching
     getOrderbooksBatch: execution.getOrderbooksBatch.bind(execution),
+    getExecutablePrice: execution.getExecutablePrice.bind(execution),
     // Circuit breaker integration
     setCircuitBreaker: execution.setCircuitBreaker.bind(execution),
     getCircuitBreakerState: execution.getCircuitBreakerState.bind(execution),

--- a/src/trading/orchestrator.ts
+++ b/src/trading/orchestrator.ts
@@ -256,6 +256,7 @@ export function createTradingOrchestrator(deps: OrchestratorDeps): TradingOrches
     approveUSDC: execution.approveUSDC.bind(execution),
     getUSDCAllowance: execution.getUSDCAllowance.bind(execution),
     getOrderbooksBatch: execution.getOrderbooksBatch.bind(execution),
+    getExecutablePrice: execution.getExecutablePrice.bind(execution),
     setCircuitBreaker: execution.setCircuitBreaker.bind(execution),
     getCircuitBreakerState: execution.getCircuitBreakerState.bind(execution),
     stop: execution.stop?.bind(execution) ?? (() => {}),

--- a/tests/execution/bracket-stop-trigger.test.ts
+++ b/tests/execution/bracket-stop-trigger.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createBracketOrder } from '../../src/execution/bracket-orders';
+import type { ExecutionService } from '../../src/execution';
+
+function createService(getPrice: () => number | null) {
+  const calls: string[] = [];
+  const service = {
+    async sellLimit(request: { price: number }) {
+      calls.push(`limit:${request.price}`);
+      return { success: true, orderId: 'take-profit', status: 'open' as const };
+    },
+    async getOrder() {
+      return { id: 'take-profit', status: 'open', price: 0.8 };
+    },
+    async getExecutablePrice() {
+      calls.push('price');
+      return getPrice();
+    },
+    async cancelOrder() {
+      calls.push('cancel-take-profit');
+      return true;
+    },
+    async marketSell() {
+      calls.push('market-sell');
+      return { success: true, orderId: 'stop-exit', status: 'filled' as const, avgFillPrice: 0.39 };
+    },
+  } as unknown as ExecutionService;
+  return { service, calls };
+}
+
+function waitForEvent(emitter: NodeJS.EventEmitter, event: string): Promise<unknown> {
+  return new Promise(resolve => emitter.once(event, resolve));
+}
+
+describe('bracket stop-loss trigger', () => {
+  it('does not rest a sell limit at the stop-loss price', async () => {
+    const { service, calls } = createService(() => 0.6);
+    const bracket = createBracketOrder(service, {
+      platform: 'polymarket',
+      marketId: 'market-1',
+      tokenId: 'token-1',
+      size: 10,
+      side: 'long',
+      takeProfitPrice: 0.8,
+      stopLossPrice: 0.4,
+      pollIntervalMs: 5,
+    }, { orderId: 'bracket-no-trigger' });
+
+    await bracket.start();
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    assert.deepEqual(calls.filter(call => call.startsWith('limit:')), ['limit:0.8']);
+    assert.equal(calls.includes('market-sell'), false);
+    await bracket.cancel();
+  });
+
+  it('cancels the take-profit before submitting a market exit after the bid crosses', async () => {
+    const { service, calls } = createService(() => 0.39);
+    const bracket = createBracketOrder(service, {
+      platform: 'polymarket',
+      marketId: 'market-1',
+      tokenId: 'token-1',
+      size: 10,
+      side: 'long',
+      takeProfitPrice: 0.8,
+      stopLossPrice: 0.4,
+      pollIntervalMs: 5,
+    }, { orderId: 'bracket-triggered' });
+    const triggered = waitForEvent(bracket, 'stop_loss_hit');
+
+    await bracket.start();
+    await triggered;
+
+    assert.deepEqual(calls.filter(call => call.startsWith('limit:')), ['limit:0.8']);
+    assert.ok(calls.indexOf('cancel-take-profit') < calls.indexOf('market-sell'));
+    assert.equal(bracket.getStatus().status, 'stop_loss_hit');
+    assert.equal(bracket.getStatus().stopLossOrderId, 'stop-exit');
+    assert.equal(bracket.getStatus().fillPrice, 0.39);
+  });
+});


### PR DESCRIPTION
Closes #114\n\n## What changed\n- stop placing the bracket stop-loss as a resting sell limit\n- monitor the executable best bid and trigger only when it crosses the configured stop\n- cancel the resting take-profit before submitting the market exit, preventing reserved-share conflicts\n- retain monitoring for legacy persisted brackets that already have a stop order ID\n- expose executable bid/ask pricing through the execution service and its wrappers\n- normalize Kalshi NO prices to the selected outcome perspective\n\n## Verification\n- 
> clodds@1.9.0 ci
> npm run typecheck && npm run test && npm run build


> clodds@1.9.0 typecheck
> tsc --noEmit


> clodds@1.9.0 test
> node --test --import tsx --import ./tests/helpers/test-setup.ts tests/**/*.test.ts

TAP version 13
# Subtest: batch order pre-trade safety
    # Subtest: returns dry-run results without requiring venue configuration
    ok 1 - returns dry-run results without requiring venue configuration
      ---
      duration_ms: 0.788125
      type: 'test'
      ...
    # Subtest: rejects invalid and oversized items before dry-run handling
    ok 2 - rejects invalid and oversized items before dry-run handling
      ---
      duration_ms: 0.167292
      type: 'test'
      ...
    # Subtest: blocks every batch item when the circuit breaker is tripped
    ok 3 - blocks every batch item when the circuit breaker is tripped
      ---
      duration_ms: 1.283375
      type: 'test'
      ...
    1..3
ok 1 - batch order pre-trade safety
  ---
  duration_ms: 2.688292
  type: 'suite'
  ...
# [2026-09-12 04:09:29.933 +0100] [31mERROR[39m: [36mCircuit breaker TRIPPED[39m
#     reason: "manual"
#     sessionPnL: 0
#     consecutiveLosses: 0
#     errorRate: 0
#     dailyTrades: 0
# Subtest: bracket stop-loss trigger
    # Subtest: does not rest a sell limit at the stop-loss price
    ok 1 - does not rest a sell limit at the stop-loss price
      ---
      duration_ms: 23.415208
      type: 'test'
      ...
    # Subtest: cancels the take-profit before submitting a market exit after the bid crosses
    ok 2 - cancels the take-profit before submitting a market exit after the bid crosses
      ---
      duration_ms: 6.643334
      type: 'test'
      ...
    1..2
ok 2 - bracket stop-loss trigger
  ---
  duration_ms: 31.518583
  type: 'suite'
  ...
# Subtest: database uses CLODDS_STATE_DIR
ok 3 - database uses CLODDS_STATE_DIR
  ---
  duration_ms: 261.423666
  type: 'test'
  ...
# Subtest: gateway health and info endpoints respond
ok 4 - gateway health and info endpoints respond
  ---
  duration_ms: 406.904875
  type: 'test'
  ...
# Subtest: market-index search endpoint validates query and returns results
ok 5 - market-index search endpoint validates query and returns results
  ---
  duration_ms: 136.037791
  type: 'test'
  ...
# Subtest: market-index stats endpoint returns stats
ok 6 - market-index stats endpoint returns stats
  ---
  duration_ms: 22.006083
  type: 'test'
  ...
# Subtest: market index sync hits real Kalshi API
ok 7 - market index sync hits real Kalshi API
  ---
  duration_ms: 457.501167
  type: 'test'
  ...
# Subtest: market index sync hits real Manifold API
ok 8 - market index sync hits real Manifold API
  ---
  duration_ms: 505.960833
  type: 'test'
  ...
# Subtest: market index sync hits real Polymarket API
ok 9 - market index sync hits real Polymarket API
  ---
  duration_ms: 528.687
  type: 'test'
  ...
# Subtest: webchat auth and message flow
ok 10 - webchat auth and message flow
  ---
  duration_ms: 18.299834
  type: 'test'
  ...
# Subtest: webhook HTTP middleware validates signature
ok 11 - webhook HTTP middleware validates signature
  ---
  duration_ms: 46.135041
  type: 'test'
  ...
# Subtest: webhook HTTP middleware enforces rate limit
ok 12 - webhook HTTP middleware enforces rate limit
  ---
  duration_ms: 10.83575
  type: 'test'
  ...
# Subtest: futures pre-trade enforcement
    # Subtest: blocks the exported execution engine above maxOrderSize
    ok 1 - blocks the exported execution engine above maxOrderSize
      ---
      duration_ms: 0.703375
      type: 'test'
      ...
    # Subtest: blocks the dynamically loaded futures engine above maxOrderSize
    ok 2 - blocks the dynamically loaded futures engine above maxOrderSize
      ---
      duration_ms: 0.37425
      type: 'test'
      ...
    # Subtest: checks the breaker before attempting market-price discovery
    ok 3 - checks the breaker before attempting market-price discovery
      ---
      duration_ms: 1.062917
      type: 'test'
      ...
    # Subtest: values MEXC contract volume with the venue contract multiplier
    ok 4 - values MEXC contract volume with the venue contract multiplier
      ---
      duration_ms: 2.857333
      type: 'test'
      ...
    1..4
ok 13 - futures pre-trade enforcement
  ---
  duration_ms: 5.7505
  type: 'suite'
  ...
# Subtest: shared pre-trade gate
    # Subtest: blocks every route when the circuit breaker is tripped
    ok 1 - blocks every route when the circuit breaker is tripped
      ---
      duration_ms: 1.358
      type: 'test'
      ...
    # Subtest: uses the strictest global and caller-specific order cap
    ok 2 - uses the strictest global and caller-specific order cap
      ---
      duration_ms: 0.314125
      type: 'test'
      ...
    # Subtest: fails closed when a route requires a missing notional
    ok 3 - fails closed when a route requires a missing notional
      ---
      duration_ms: 0.409875
      type: 'test'
      ...
    # Subtest: allows risk-reducing exits over the size cap but still honors kill switches
    ok 4 - allows risk-reducing exits over the size cap but still honors kill switches
      ---
      duration_ms: 0.402792
      type: 'test'
      ...
    1..4
ok 14 - shared pre-trade gate
  ---
  duration_ms: 3.7365
  type: 'suite'
  ...
# Subtest: Solana swap notional valuation
    # Subtest: values USDC inputs directly from base units
    ok 1 - values USDC inputs directly from base units
      ---
      duration_ms: 0.370625
      type: 'test'
      ...
    # Subtest: values non-USDC inputs through a Jupiter USDC quote
    ok 2 - values non-USDC inputs through a Jupiter USDC quote
      ---
      duration_ms: 0.081666
      type: 'test'
      ...
    # Subtest: resolves the required input before valuing exact-output swaps
    ok 3 - resolves the required input before valuing exact-output swaps
      ---
      duration_ms: 0.364334
      type: 'test'
      ...
    1..3
ok 15 - Solana swap notional valuation
  ---
  duration_ms: 1.269417
  type: 'suite'
  ...
# Subtest: sentiment analyzer
    # Subtest: scores bullish text positively
    ok 1 - scores bullish text positively
      ---
      duration_ms: 11.342917
      type: 'test'
      ...
    # Subtest: scores bearish text negatively
    ok 2 - scores bearish text negatively
      ---
      duration_ms: 3.207
      type: 'test'
      ...
    # Subtest: handles negation (not bullish → bearish)
    ok 3 - handles negation (not bullish → bearish)
      ---
      duration_ms: 1.052125
      type: 'test'
      ...
    # Subtest: scores Fear & Greed numeric value
    ok 4 - scores Fear & Greed numeric value
      ---
      duration_ms: 1.382
      type: 'test'
      ...
    # Subtest: scores funding rate as contrarian signal
    ok 5 - scores funding rate as contrarian signal
      ---
      duration_ms: 1.981
      type: 'test'
      ...
    # Subtest: returns neutral for empty/irrelevant text
    ok 6 - returns neutral for empty/irrelevant text
      ---
      duration_ms: 1.279458
      type: 'test'
      ...
    # Subtest: detects politics category
    ok 7 - detects politics category
      ---
      duration_ms: 2.197208
      type: 'test'
      ...
    # Subtest: detects economics category
    ok 8 - detects economics category
      ---
      duration_ms: 1.535875
      type: 'test'
      ...
    1..8
ok 16 - sentiment analyzer
  ---
  duration_ms: 25.942209
  type: 'suite'
  ...
# Subtest: market matcher
    # Subtest: matches by keyword overlap
    ok 1 - matches by keyword overlap
      ---
      duration_ms: 26.119625
      type: 'test'
      ...
    # Subtest: matches by category
    ok 2 - matches by category
      ---
      duration_ms: 4.237333
      type: 'test'
      ...
    # Subtest: returns empty when no markets loaded
    ok 3 - returns empty when no markets loaded
      ---
      duration_ms: 3.379167
      type: 'test'
      ...
    1..3
ok 17 - market matcher
  ---
  duration_ms: 34.010417
  type: 'suite'
  ...
# Subtest: alt-data service
    # Subtest: processes events through full pipeline
    ok 1 - processes events through full pipeline
      ---
      duration_ms: 21.945292
      type: 'test'
      ...
    # Subtest: getRecentSignals returns empty initially
    ok 2 - getRecentSignals returns empty initially
      ---
      duration_ms: 4.962792
      type: 'test'
      ...
    1..2
ok 18 - alt-data service
  ---
  duration_ms: 27.210417
  type: 'suite'
  ...
# Subtest: fear-greed feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 4.9985
      type: 'test'
      ...
    1..1
ok 19 - fear-greed feed
  ---
  duration_ms: 5.129667
  type: 'suite'
  ...
# Subtest: funding-rates feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 2.757958
      type: 'test'
      ...
    1..1
ok 20 - funding-rates feed
  ---
  duration_ms: 2.836166
  type: 'suite'
  ...
# Subtest: reddit feed
    # Subtest: creates feed with start/stop lifecycle
    ok 1 - creates feed with start/stop lifecycle
      ---
      duration_ms: 2.057458
      type: 'test'
      ...
    1..1
ok 21 - reddit feed
  ---
  duration_ms: 2.278708
  type: 'suite'
  ...
# Subtest: runtime model defaults do not use retired Anthropic IDs
ok 22 - runtime model defaults do not use retired Anthropic IDs
  ---
  duration_ms: 1.26575
  type: 'test'
  ...
# Subtest: Anthropic provider uses active defaults for completion and health checks
ok 23 - Anthropic provider uses active defaults for completion and health checks
  ---
  duration_ms: 12.601583
  type: 'test'
  ...
# Subtest: backtest engine
    # Subtest: creates engine with all methods
    ok 1 - creates engine with all methods
      ---
      duration_ms: 31.205375
      type: 'test'
      ...
    # Subtest: returns empty result for no ticks
    ok 2 - returns empty result for no ticks
      ---
      duration_ms: 2.255583
      type: 'test'
      ...
    # Subtest: executes buy-and-hold strategy on tick data
    ok 3 - executes buy-and-hold strategy on tick data
      ---
      duration_ms: 3.755958
      type: 'test'
      ...
    # Subtest: handles buy and sell signals correctly
    ok 4 - handles buy and sell signals correctly
      ---
      duration_ms: 2.690416
      type: 'test'
      ...
    # Subtest: respects eval interval
    ok 5 - respects eval interval
      ---
      duration_ms: 1.599458
      type: 'test'
      ...
    # Subtest: applies commission and slippage
    ok 6 - applies commission and slippage
      ---
      duration_ms: 3.804084
      type: 'test'
      ...
    # Subtest: finds orderbook snapshots via binary search
    ok 7 - finds orderbook snapshots via binary search
      ---
      duration_ms: 1.818625
      type: 'test'
      ...
    # Subtest: calls strategy init and cleanup
    ok 8 - calls strategy init and cleanup
      ---
      duration_ms: 1.889792
      type: 'test'
      ...
    1..8
ok 24 - backtest engine
  ---
  duration_ms: 50.575625
  type: 'suite'
  ...
# Subtest: backtest monte carlo
    # Subtest: runs monte carlo simulation
    ok 1 - runs monte carlo simulation
      ---
      duration_ms: 3.148042
      type: 'test'
      ...
    # Subtest: handles empty returns
    ok 2 - handles empty returns
      ---
      duration_ms: 0.842666
      type: 'test'
      ...
    1..2
ok 25 - backtest monte carlo
  ---
  duration_ms: 4.372
  type: 'suite'
  ...
# Subtest: backtest metrics
    # Subtest: calculates correct metrics for winning trades
    ok 1 - calculates correct metrics for winning trades
      ---
      duration_ms: 6.355292
      type: 'test'
      ...
    1..1
ok 26 - backtest metrics
  ---
  duration_ms: 6.44175
  type: 'suite'
  ...
# Subtest: built-in strategies
    # Subtest: mean reversion strategy has correct config
    ok 1 - mean reversion strategy has correct config
      ---
      duration_ms: 22.00425
      type: 'test'
      ...
    # Subtest: momentum strategy has correct config
    ok 2 - momentum strategy has correct config
      ---
      duration_ms: 1.9095
      type: 'test'
      ...
    # Subtest: strategies accept custom params
    ok 3 - strategies accept custom params
      ---
      duration_ms: 3.286791
      type: 'test'
      ...
    1..3
ok 27 - built-in strategies
  ---
  duration_ms: 27.346917
  type: 'suite'
  ...
# Subtest: bittensor wallet
    # Subtest: raoToTao converts 1 billion rao to 1 TAO
    ok 1 - raoToTao converts 1 billion rao to 1 TAO
      ---
      duration_ms: 0.792958
      type: 'test'
      ...
    1..1
ok 28 - bittensor wallet
  ---
  duration_ms: 1.498666
  type: 'suite'
  ...
# Subtest: bittensor python-runner
    # Subtest: sanitizeArg strips dangerous shell characters
    ok 1 - sanitizeArg strips dangerous shell characters
      ---
      duration_ms: 30.016417
      type: 'test'
      ...
    # Subtest: createPythonRunner returns object with exec, spawn, btcli
    ok 2 - createPythonRunner returns object with exec, spawn, btcli
      ---
      duration_ms: 1.984792
      type: 'test'
      ...
    1..2
ok 29 - bittensor python-runner
  ---
  duration_ms: 32.265667
  type: 'suite'
  ...
# Subtest: bittensor chutes manager
    # Subtest: initializes with GPU nodes from config
    ok 1 - initializes with GPU nodes from config
      ---
      duration_ms: 7.252292
      type: 'test'
      ...
    # Subtest: addGpuNode and removeGpuNode work correctly
    ok 2 - addGpuNode and removeGpuNode work correctly
      ---
      duration_ms: 3.406333
      type: 'test'
      ...
    # Subtest: getInvocationStats returns zero when not started
    ok 3 - getInvocationStats returns zero when not started
      ---
      duration_ms: 1.579917
      type: 'test'
      ...
    1..3
ok 30 - bittensor chutes manager
  ---
  duration_ms: 13.144542
  type: 'suite'
  ...
# Subtest: bittensor persistence
    # Subtest: init creates all three tables
    ok 1 - init creates all three tables
      ---
      duration_ms: 6.626125
      type: 'test'
      ...
    # Subtest: saveEarnings and getEarnings round-trip
    ok 2 - saveEarnings and getEarnings round-trip
      ---
      duration_ms: 3.5425
      type: 'test'
      ...
    # Subtest: saveMinerStatus and getMinerStatus round-trip
    ok 3 - saveMinerStatus and getMinerStatus round-trip
      ---
      duration_ms: 1.798209
      type: 'test'
      ...
    # Subtest: saveMinerStatus upserts on conflict
    ok 4 - saveMinerStatus upserts on conflict
      ---
      duration_ms: 2.303125
      type: 'test'
      ...
    # Subtest: getMinerStatuses returns all rows
    ok 5 - getMinerStatuses returns all rows
      ---
      duration_ms: 3.515833
      type: 'test'
      ...
    # Subtest: logCost and getCosts round-trip
    ok 6 - logCost and getCosts round-trip
      ---
      duration_ms: 1.219375
      type: 'test'
      ...
    # Subtest: getMinerStatus returns null for missing entry
    ok 7 - getMinerStatus returns null for missing entry
      ---
      duration_ms: 0.344333
      type: 'test'
      ...
    1..7
ok 31 - bittensor persistence
  ---
  duration_ms: 19.99575
  type: 'suite'
  ...
# Subtest: bittensor handler
    # Subtest: returns error when service is not set
    ok 1 - returns error when service is not set
      ---
      duration_ms: 5.597042
      type: 'test'
      ...
    # Subtest: returns status when service is set
    ok 2 - returns status when service is set
      ---
      duration_ms: 0.614375
      type: 'test'
      ...
    # Subtest: returns earnings for a period
    ok 3 - returns earnings for a period
      ---
      duration_ms: 0.735791
      type: 'test'
      ...
    # Subtest: returns error for unknown action
    ok 4 - returns error for unknown action
      ---
      duration_ms: 0.365834
      type: 'test'
      ...
    # Subtest: requires subnetId for start/stop/register
    ok 5 - requires subnetId for start/stop/register
      ---
      duration_ms: 0.565125
      type: 'test'
      ...
    1..5
ok 32 - bittensor handler
  ---
  duration_ms: 8.041084
  type: 'suite'
  ...
# Subtest: bittensor router
    # Subtest: creates a router with all expected routes
    ok 1 - creates a router with all expected routes
      ---
      duration_ms: 94.162917
      type: 'test'
      ...
    1..1
ok 33 - bittensor router
  ---
  duration_ms: 94.272625
  type: 'suite'
  ...
# Subtest: BotManager
    # Subtest: creates bot manager with default config
    ok 1 - creates bot manager with default config
      ---
      duration_ms: 21.423375
      type: 'test'
      ...
    # Subtest: registers and lists strategies
    ok 2 - registers and lists strategies
      ---
      duration_ms: 7.27325
      type: 'test'
      ...
    # Subtest: getStrategy returns Strategy by ID
    ok 3 - getStrategy returns Strategy by ID
      ---
      duration_ms: 41.836
      type: 'test'
      ...
    # Subtest: getStrategy returns null for unknown ID
    ok 4 - getStrategy returns null for unknown ID
      ---
      duration_ms: 6.498916
      type: 'test'
      ...
    # Subtest: returns bot statuses
    ok 5 - returns bot statuses
      ---
      duration_ms: 3.9215
      type: 'test'
      ...
    # Subtest: getTradeLogger returns a logger instance
    ok 6 - getTradeLogger returns a logger instance
      ---
      duration_ms: 3.103
      type: 'test'
      ...
    1..6
ok 34 - BotManager
  ---
  duration_ms: 86.006333
  type: 'suite'
  ...
# Subtest: BotManager with shared TradeLogger
    # Subtest: uses external tradeLogger when provided
    ok 1 - uses external tradeLogger when provided
      ---
      duration_ms: 7.0475
      type: 'test'
      ...
    # Subtest: creates own tradeLogger when not provided
    ok 2 - creates own tradeLogger when not provided
      ---
      duration_ms: 1.842709
      type: 'test'
      ...
    1..2
ok 35 - BotManager with shared TradeLogger
  ---
  duration_ms: 9.092417
  type: 'suite'
  ...
# Subtest: BotManager with execution callbacks
    # Subtest: accepts executeOrder callback
    ok 1 - accepts executeOrder callback
      ---
      duration_ms: 1.864625
      type: 'test'
      ...
    # Subtest: accepts getPrice callback
    ok 2 - accepts getPrice callback
      ---
      duration_ms: 1.933625
      type: 'test'
      ...
    # Subtest: accepts getMarket callback
    ok 3 - accepts getMarket callback
      ---
      duration_ms: 5.246083
      type: 'test'
      ...
    # Subtest: accepts getPortfolio callback
    ok 4 - accepts getPortfolio callback
      ---
      duration_ms: 2.38975
      type: 'test'
      ...
    1..4
ok 36 - BotManager with execution callbacks
  ---
  duration_ms: 13.218541
  type: 'suite'
  ...
# Subtest: StrategyBuilder
    # Subtest: creates strategy builder
    ok 1 - creates strategy builder
      ---
      duration_ms: 6.763
      type: 'test'
      ...
    # Subtest: lists available templates
    ok 2 - lists available templates
      ---
      duration_ms: 0.97025
      type: 'test'
      ...
    # Subtest: validates a strategy definition
    ok 3 - validates a strategy definition
      ---
      duration_ms: 1.089
      type: 'test'
      ...
    1..3
ok 37 - StrategyBuilder
  ---
  duration_ms: 10.8925
  type: 'suite'
  ...
# Subtest: Trading Adapters
    # Subtest: creates crypto HFT adapter as Strategy
    ok 1 - creates crypto HFT adapter as Strategy
      ---
      duration_ms: 5.761417
      type: 'test'
      ...
    # Subtest: creates divergence adapter as Strategy
    ok 2 - creates divergence adapter as Strategy
      ---
      duration_ms: 1.524292
      type: 'test'
      ...
    # Subtest: crypto HFT adapter evaluate returns empty when engine not started
    ok 3 - crypto HFT adapter evaluate returns empty when engine not started
      ---
      duration_ms: 3.026333
      type: 'test'
      ...
    # Subtest: divergence adapter evaluate returns empty when engine not started
    ok 4 - divergence adapter evaluate returns empty when engine not started
      ---
      duration_ms: 5.152
      type: 'test'
      ...
    # Subtest: adapters can be registered in BotManager
    ok 5 - adapters can be registered in BotManager
      ---
      duration_ms: 7.811125
      type: 'test'
      ...
    1..5
ok 38 - Trading Adapters
  ---
  duration_ms: 23.793541
  type: 'suite'
  ...
# Subtest: Config env var overrides
    # Subtest: maps Discord credentials into the runtime channel config
    ok 1 - maps Discord credentials into the runtime channel config
      ---
      duration_ms: 21.963584
      type: 'test'
      ...
    # Subtest: MARKET_MAKING_ENABLED sets config.trading.marketMaking.enabled
    ok 2 - MARKET_MAKING_ENABLED sets config.trading.marketMaking.enabled
      ---
      duration_ms: 2.506292
      type: 'test'
      ...
    # Subtest: CRYPTO_HFT_ENABLED sets config.trading.cryptoHft.enabled
    ok 3 - CRYPTO_HFT_ENABLED sets config.trading.cryptoHft.enabled
      ---
      duration_ms: 1.488417
      type: 'test'
      ...
    # Subtest: HFT_DIVERGENCE_ENABLED sets config.trading.hftDivergence.enabled
    ok 4 - HFT_DIVERGENCE_ENABLED sets config.trading.hftDivergence.enabled
      ---
      duration_ms: 3.697875
      type: 'test'
      ...
    1..4
ok 39 - Config env var overrides
  ---
  duration_ms: 29.925042
  type: 'suite'
  ...
# [2026-09-12 04:09:29.895 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# [2026-09-12 04:09:29.902 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# [2026-09-12 04:09:29.905 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# [2026-09-12 04:09:29.908 +0100] [31mERROR[39m (config): [36mFailed to parse config file[39m
#     configPath: "/dev/null"
#     error: {
#       "lineNumber": 1,
#       "columnNumber": 1
#     }
# Subtest: risk command parses settings and updates user
ok 40 - risk command parses settings and updates user
  ---
  duration_ms: 2.215625
  type: 'test'
  ...
# Subtest: risk command rejects invalid input
ok 41 - risk command rejects invalid input
  ---
  duration_ms: 0.122833
  type: 'test'
  ...
# Subtest: digest command parses time and enables
ok 42 - digest command parses time and enables
  ---
  duration_ms: 0.19175
  type: 'test'
  ...
# Subtest: compare command parses platforms and limit
ok 43 - compare command parses platforms and limit
  ---
  duration_ms: 11.17975
  type: 'test'
  ...
# Subtest: markets command errors on empty args
ok 44 - markets command errors on empty args
  ---
  duration_ms: 0.191667
  type: 'test'
  ...
# Subtest: markets command treats single token as query
ok 45 - markets command treats single token as query
  ---
  duration_ms: 0.126541
  type: 'test'
  ...
# Subtest: arbitrage command parses args and uses minEdge
ok 46 - arbitrage command parses args and uses minEdge
  ---
  duration_ms: 0.361625
  type: 'test'
  ...
# Subtest: pnl command parses args and passes since/limit to db
ok 47 - pnl command parses args and passes since/limit to db
  ---
  duration_ms: 0.274833
  type: 'test'
  ...
# Subtest: resolveStateDir uses override
ok 48 - resolveStateDir uses override
  ---
  duration_ms: 0.372208
  type: 'test'
  ...
# Subtest: resolveConfigPath uses override
ok 49 - resolveConfigPath uses override
  ---
  duration_ms: 0.062083
  type: 'test'
  ...
# Subtest: resolveWorkspaceDir uses override
ok 50 - resolveWorkspaceDir uses override
  ---
  duration_ms: 0.053542
  type: 'test'
  ...
# Subtest: fast-broadcast byte parity with ethers wallet.sendTransaction
    # Subtest: produces the exact same signed raw transaction bytes as the native ethers path
    ok 1 - produces the exact same signed raw transaction bytes as the native ethers path
      ---
      duration_ms: 152.404667
      type: 'test'
      ...
    1..1
ok 51 - fast-broadcast byte parity with ethers wallet.sendTransaction
  ---
  duration_ms: 153.109125
  type: 'suite'
  ...
# Subtest: fast-broadcast (Rust worker via TS wrapper)
ok 52 - fast-broadcast (Rust worker via TS wrapper) # SKIP fast-broadcast Rust binary not built — run `cargo build` in rust/fast-broadcast/
  ---
  duration_ms: 0.250958
  type: 'suite'
  ...
# Subtest: market index search boosts text matches
ok 53 - market index search boosts text matches
  ---
  duration_ms: 1.695167
  type: 'test'
  ...
# Subtest: market index search applies platform weights
ok 54 - market index search applies platform weights
  ---
  duration_ms: 0.311084
  type: 'test'
  ...
# Subtest: market index search honors minScore
ok 55 - market index search honors minScore
  ---
  duration_ms: 0.502541
  type: 'test'
  ...
# Subtest: ml-pipeline types
    # Subtest: exports default quality gates
    ok 1 - exports default quality gates
      ---
      duration_ms: 4.984917
      type: 'test'
      ...
    1..1
ok 56 - ml-pipeline types
  ---
  duration_ms: 5.712834
  type: 'suite'
  ...
# Subtest: combinedToMarketFeatures
    # Subtest: handles null combined features
    ok 1 - handles null combined features
      ---
      duration_ms: 14.412917
      type: 'test'
      ...
    # Subtest: maps tick features correctly
    ok 2 - maps tick features correctly
      ---
      duration_ms: 1.256459
      type: 'test'
      ...
    # Subtest: maps orderbook features correctly
    ok 3 - maps orderbook features correctly
      ---
      duration_ms: 0.7935
      type: 'test'
      ...
    1..3
ok 57 - combinedToMarketFeatures
  ---
  duration_ms: 16.825291
  type: 'suite'
  ...
# Subtest: ml collector
    # Subtest: creates ml_training_samples table on init
    ok 1 - creates ml_training_samples table on init
      ---
      duration_ms: 6.010125
      type: 'test'
      ...
    # Subtest: captures signal on executed event
    ok 2 - captures signal on executed event
      ---
      duration_ms: 3.063042
      type: 'test'
      ...
    # Subtest: captures signal on dry_run event
    ok 3 - captures signal on dry_run event
      ---
      duration_ms: 1.348833
      type: 'test'
      ...
    # Subtest: returns sample counts
    ok 4 - returns sample counts
      ---
      duration_ms: 1.595791
      type: 'test'
      ...
    # Subtest: stops cleanly
    ok 5 - stops cleanly
      ---
      duration_ms: 1.067459
      type: 'test'
      ...
    1..5
ok 58 - ml collector
  ---
  duration_ms: 13.702917
  type: 'suite'
  ...
# Subtest: ml trainer
    # Subtest: creates trainer with stats
    ok 1 - creates trainer with stats
      ---
      duration_ms: 4.943916
      type: 'test'
      ...
    # Subtest: skips training with too few samples
    ok 2 - skips training with too few samples
      ---
      duration_ms: 1.3735
      type: 'test'
      ...
    # Subtest: starts and stops cleanly
    ok 3 - starts and stops cleanly
      ---
      duration_ms: 0.728792
      type: 'test'
      ...
    1..3
ok 59 - ml trainer
  ---
  duration_ms: 7.183917
  type: 'suite'
  ...
# Subtest: ml pipeline factory
    # Subtest: creates pipeline with model
    ok 1 - creates pipeline with model
      ---
      duration_ms: 2.450666
      type: 'test'
      ...
    # Subtest: returns stats
    ok 2 - returns stats
      ---
      duration_ms: 0.9775
      type: 'test'
      ...
    # Subtest: starts and stops with signal router
    ok 3 - starts and stops with signal router
      ---
      duration_ms: 0.955333
      type: 'test'
      ...
    1..3
ok 60 - ml pipeline factory
  ---
  duration_ms: 4.537334
  type: 'suite'
  ...
# Subtest: signal router with ML model
    # Subtest: accepts optional mlModel parameter
    ok 1 - accepts optional mlModel parameter
      ---
      duration_ms: 5.482417
      type: 'test'
      ...
    # Subtest: works without mlModel (backward compatible)
    ok 2 - works without mlModel (backward compatible)
      ---
      duration_ms: 2.272625
      type: 'test'
      ...
    1..2
ok 61 - signal router with ML model
  ---
  duration_ms: 7.888667
  type: 'suite'
  ...
# Subtest: multi-hop arbitrage planner
    # Subtest: finds a profitable three-hop cycle
    ok 1 - finds a profitable three-hop cycle
      ---
      duration_ms: 0.8795
      type: 'test'
      ...
    # Subtest: marks all-solana paths as atomic bundles when every hop is bundle-eligible
    ok 2 - marks all-solana paths as atomic bundles when every hop is bundle-eligible
      ---
      duration_ms: 0.219875
      type: 'test'
      ...
    # Subtest: marks all-evm paths as exact-in for deterministic entry sizing
    ok 3 - marks all-evm paths as exact-in for deterministic entry sizing
      ---
      duration_ms: 0.207209
      type: 'test'
      ...
    1..3
ok 62 - multi-hop arbitrage planner
  ---
  duration_ms: 1.783625
  type: 'suite'
  ...
# Subtest: multichain getRaceUrls
    # Subtest: defaults to just the primary RPC when no fallbacks are configured
    ok 1 - defaults to just the primary RPC when no fallbacks are configured
      ---
      duration_ms: 567.262458
      type: 'test'
      ...
    # Subtest: includes configured fallbacks after the primary, trimmed
    ok 2 - includes configured fallbacks after the primary, trimmed
      ---
      duration_ms: 413.552667
      type: 'test'
      ...
    # Subtest: dedupes a fallback that matches the primary
    ok 3 - dedupes a fallback that matches the primary
      ---
      duration_ms: 338.7525
      type: 'test'
      ...
    1..3
ok 63 - multichain getRaceUrls
  ---
  duration_ms: 1320.105917
  type: 'suite'
  ...
# Subtest: opportunity hft integration
    # Subtest: builds a live venue plan from an opportunity and uses outcome token ids for polymarket
    ok 1 - builds a live venue plan from an opportunity and uses outcome token ids for polymarket
      ---
      duration_ms: 1.295292
      type: 'test'
      ...
    # Subtest: builds live linked-market venue plans from market identity groups
    ok 2 - builds live linked-market venue plans from market identity groups
      ---
      duration_ms: 0.693208
      type: 'test'
      ...
    # Subtest: derives NO-side pricing from binary yes orderbooks when venue lookup is market-level only
    ok 3 - derives NO-side pricing from binary yes orderbooks when venue lookup is market-level only
      ---
      duration_ms: 0.734667
      type: 'test'
      ...
    1..3
ok 64 - opportunity hft integration
  ---
  duration_ms: 3.310958
  type: 'suite'
  ...
# Subtest: Polymarket V2 order signer byte parity with ethers EIP-712
    # Subtest: produces a byte-identical signature to an independent ethers reference (standard exchange, BUY)
    ok 1 - produces a byte-identical signature to an independent ethers reference (standard exchange, BUY)
      ---
      duration_ms: 69.219666
      type: 'test'
      ...
    # Subtest: produces a byte-identical signature to an independent ethers reference (negRisk exchange, SELL)
    ok 2 - produces a byte-identical signature to an independent ethers reference (negRisk exchange, SELL)
      ---
      duration_ms: 7.3045
      type: 'test'
      ...
    # Subtest: defaults metadata/builder to 32 zero bytes and rejects POLY_1271
    ok 3 - defaults metadata/builder to 32 zero bytes and rejects POLY_1271
      ---
      duration_ms: 1.444208
      type: 'test'
      ...
    1..3
ok 65 - Polymarket V2 order signer byte parity with ethers EIP-712
  ---
  duration_ms: 78.486792
  type: 'suite'
  ...
# Subtest: enforceMaxOrderSize blocks oversized order
ok 66 - enforceMaxOrderSize blocks oversized order
  ---
  duration_ms: 0.540917
  type: 'test'
  ...
# Subtest: enforceMaxOrderSize allows small or invalid notional
ok 67 - enforceMaxOrderSize allows small or invalid notional
  ---
  duration_ms: 0.07375
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks maxTotalExposure
ok 68 - enforceExposureLimits blocks maxTotalExposure
  ---
  duration_ms: 0.175917
  type: 'test'
  ...
# Subtest: enforceExposureLimits ignores non-positive notional
ok 69 - enforceExposureLimits ignores non-positive notional
  ---
  duration_ms: 0.056208
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks maxPositionValue
ok 70 - enforceExposureLimits blocks maxPositionValue
  ---
  duration_ms: 0.134334
  type: 'test'
  ...
# Subtest: enforceExposureLimits skips maxPositionValue when market/outcome missing
ok 71 - enforceExposureLimits skips maxPositionValue when market/outcome missing
  ---
  duration_ms: 0.059959
  type: 'test'
  ...
# Subtest: enforceExposureLimits blocks stop-loss threshold
ok 72 - enforceExposureLimits blocks stop-loss threshold
  ---
  duration_ms: 0.074459
  type: 'test'
  ...
# Subtest: enforceExposureLimits returns null when no limits configured
ok 73 - enforceExposureLimits returns null when no limits configured
  ---
  duration_ms: 0.054375
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage report summarizes reuse targets
ok 74 - rust-hft-arbitrage report summarizes reuse targets
  ---
  duration_ms: 1.14725
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage venues command lists concrete venues
ok 75 - rust-hft-arbitrage venues command lists concrete venues
  ---
  duration_ms: 0.247209
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan help shows usage without hitting the network
ok 76 - rust-hft-arbitrage scan help shows usage without hitting the network
  ---
  duration_ms: 0.279667
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan rejects an unknown family before scanning
ok 77 - rust-hft-arbitrage scan rejects an unknown family before scanning
  ---
  duration_ms: 0.338041
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan requires size and tokens
ok 78 - rust-hft-arbitrage scan requires size and tokens
  ---
  duration_ms: 0.140458
  type: 'test'
  ...
# Subtest: rust-hft-arbitrage scan requires a valid chain for evm/cross families
ok 79 - rust-hft-arbitrage scan requires a valid chain for evm/cross families
  ---
  duration_ms: 0.182417
  type: 'test'
  ...
# Subtest: signal router
    # Subtest: creates with start/stop lifecycle
    ok 1 - creates with start/stop lifecycle
      ---
      duration_ms: 24.59175
      type: 'test'
      ...
    # Subtest: rejects signals below min strength
    ok 2 - rejects signals below min strength
      ---
      duration_ms: 53.298
      type: 'test'
      ...
    # Subtest: rejects neutral direction signals
    ok 3 - rejects neutral direction signals
      ---
      duration_ms: 57.183583
      type: 'test'
      ...
    # Subtest: filters by signal type
    ok 4 - filters by signal type
      ---
      duration_ms: 60.24475
      type: 'test'
      ...
    # Subtest: filters by platform
    ok 5 - filters by platform
      ---
      duration_ms: 53.138334
      type: 'test'
      ...
    # Subtest: enforces per-market cooldown
    ok 6 - enforces per-market cooldown
      ---
      duration_ms: 107.392958
      type: 'test'
      ...
    # Subtest: rejects when no price data available
    ok 7 - rejects when no price data available
      ---
      duration_ms: 54.993
      type: 'test'
      ...
    # Subtest: tracks recent executions
    ok 8 - tracks recent executions
      ---
      duration_ms: 51.470667
      type: 'test'
      ...
    # Subtest: respects daily loss limit
    ok 9 - respects daily loss limit
      ---
      duration_ms: 52.213542
      type: 'test'
      ...
    # Subtest: enforces max concurrent positions
    ok 10 - enforces max concurrent positions
      ---
      duration_ms: 51.464375
      type: 'test'
      ...
    # Subtest: updateConfig changes behavior
    ok 11 - updateConfig changes behavior
      ---
      duration_ms: 0.499708
      type: 'test'
      ...
    # Subtest: resetDailyStats clears counters
    ok 12 - resetDailyStats clears counters
      ---
      duration_ms: 51.543167
      type: 'test'
      ...
    1..12
ok 80 - signal router
  ---
  duration_ms: 619.301125
  type: 'suite'
  ...
# Subtest: computeWeightedAverageFill
    # Subtest: fills fully within a single level
    ok 1 - fills fully within a single level
      ---
      duration_ms: 0.419458
      type: 'test'
      ...
    # Subtest: walks multiple levels and reports partial fills when depth runs out
    ok 2 - walks multiple levels and reports partial fills when depth runs out
      ---
      duration_ms: 0.118583
      type: 'test'
      ...
    # Subtest: returns null for empty or invalid book depth
    ok 3 - returns null for empty or invalid book depth
      ---
      duration_ms: 0.047708
      type: 'test'
      ...
    1..3
ok 81 - computeWeightedAverageFill
  ---
  duration_ms: 1.028125
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (solana)
    # Subtest: finds a crossed plan between two solana venues and prices it sanely
    ok 1 - finds a crossed plan between two solana venues and prices it sanely
      ---
      duration_ms: 15.187291
      type: 'test'
      ...
    # Subtest: picks pumpswap as the cheapest venue among three solana AMMs
    ok 2 - picks pumpswap as the cheapest venue among three solana AMMs
      ---
      duration_ms: 0.957625
      type: 'test'
      ...
    # Subtest: routes a failing venue into skipped without dropping the rest
    ok 3 - routes a failing venue into skipped without dropping the rest
      ---
      duration_ms: 0.297167
      type: 'test'
      ...
    1..3
ok 82 - scanVenueArbitrage (solana)
  ---
  duration_ms: 16.625291
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (evm)
    # Subtest: finds a crossed plan between uniswap and lighter on arbitrum
    ok 1 - finds a crossed plan between uniswap and lighter on arbitrum
      ---
      duration_ms: 0.639541
      type: 'test'
      ...
    # Subtest: rejects lighter quoting outside arbitrum
    ok 2 - rejects lighter quoting outside arbitrum
      ---
      duration_ms: 0.096292
      type: 'test'
      ...
    1..2
ok 83 - scanVenueArbitrage (evm)
  ---
  duration_ms: 0.908833
  type: 'suite'
  ...
# Subtest: scanVenueArbitrage (cross-chain)
    # Subtest: combines solana and evm legs and flags the pre-positioned inventory assumption
    ok 1 - combines solana and evm legs and flags the pre-positioned inventory assumption
      ---
      duration_ms: 0.448083
      type: 'test'
      ...
    1..1
ok 84 - scanVenueArbitrage (cross-chain)
  ---
  duration_ms: 0.571625
  type: 'suite'
  ...
# Subtest: venue arbitrage planner
    # Subtest: finds a net-positive crossed venue arbitrage plan
    ok 1 - finds a net-positive crossed venue arbitrage plan
      ---
      duration_ms: 1.6235
      type: 'test'
      ...
    # Subtest: drops stale quotes before planning
    ok 2 - drops stale quotes before planning
      ---
      duration_ms: 0.216292
      type: 'test'
      ...
    # Subtest: penalizes slower venues enough to prefer the faster route
    ok 3 - penalizes slower venues enough to prefer the faster route
      ---
      duration_ms: 2.740417
      type: 'test'
      ...
    # Subtest: supports maker-taker execution sequencing
    ok 4 - supports maker-taker execution sequencing
      ---
      duration_ms: 0.19325
      type: 'test'
      ...
    # Subtest: can surface queue-based maker opportunities when crossed-market mode is disabled
    ok 5 - can surface queue-based maker opportunities when crossed-market mode is disabled
      ---
      duration_ms: 0.175833
      type: 'test'
      ...
    # Subtest: accepts Solana and EVM venue identifiers in the planner
    ok 6 - accepts Solana and EVM venue identifiers in the planner
      ---
      duration_ms: 0.174833
      type: 'test'
      ...
    1..6
ok 85 - venue arbitrage planner
  ---
  duration_ms: 6.034875
  type: 'suite'
  ...
# Subtest: webhook manager rejects invalid signature
ok 86 - webhook manager rejects invalid signature
  ---
  duration_ms: 0.607
  type: 'test'
  ...
# Subtest: webhook manager enforces rate limit
ok 87 - webhook manager enforces rate limit
  ---
  duration_ms: 0.160292
  type: 'test'
  ...
1..87
# tests 188
# suites 45
# pass 188
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 4918.721

> clodds@1.9.0 build
> tsc && node -e "const{cpSync,readdirSync}=require('fs'),p=require('path');readdirSync('src/skills/bundled',{withFileTypes:true}).filter(d=>d.isDirectory()).forEach(d=>{const s=p.join('src/skills/bundled',d.name,'SKILL.md'),t=p.join('dist/skills/bundled',d.name,'SKILL.md');try{cpSync(s,t)}catch{}})"\n- 188 tests passed\n- TypeScript typecheck passed\n- production build passed