### PR TITLE
fix: publish required postinstall scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
   "files": [
     "dist",
     "public",
+    "scripts/fix-native-bindings.js",
+    "scripts/fix-anchor-bn-export.js",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Closes #113\n\nWhat changed:\n- include the two JavaScript files invoked by postinstall in the npm package allowlist\n- keep unrelated development and capture scripts out of the published tarball\n\nVerification:\n- npm pack --dry-run --ignore-scripts --json includes scripts/fix-native-bindings.js and scripts/fix-anchor-bn-export.js\n- npm run ci\n- 188 tests passed\n- TypeScript typecheck and production build passed