### PR TITLE
fix: restore ledger storage test execution

### DIFF
--- a/src/execution/circuit-breaker.ts
+++ b/src/execution/circuit-breaker.ts
@@ -186,12 +186,20 @@ export function createCircuitBreaker(
         reset();
       }
     }, cfg.resetTimeoutMs);
+    // A tripped standalone breaker should not keep a CLI or test process alive.
+    // Gateway processes remain alive through their servers and monitoring loop.
+    autoResetTimer.unref?.();
   }
 
   /**
    * Reset the circuit breaker
    */
   function reset(): void {
+    if (autoResetTimer) {
+      clearTimeout(autoResetTimer);
+      autoResetTimer = null;
+    }
+
     logger.info({ previousReason: tripReason }, 'Circuit breaker RESET');
 
     isTripped = false;

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -255,11 +255,20 @@ export function createMockDb(): LedgerDb & {
         );
       }
 
-      // Handle ORDER BY and LIMIT
-      const limitMatch = sql.match(/LIMIT (\d+)/i);
-      if (limitMatch) {
-        const limit = parseInt(limitMatch[1], 10);
-        result = result.slice(0, limit);
+      // Handle ORDER BY, LIMIT, and OFFSET in both literal and bound-parameter
+      // forms. Production queries bind these values, so the mock must preserve
+      // the same pagination semantics.
+      const literalLimit = sql.match(/LIMIT\s+(\d+)/i);
+      const boundLimit = /LIMIT\s+\?/i.test(sql);
+      const boundOffset = /OFFSET\s+\?/i.test(sql);
+      const limit = literalLimit
+        ? parseInt(literalLimit[1], 10)
+        : boundLimit
+          ? Number(params[params.length - (boundOffset ? 2 : 1)])
+          : undefined;
+      const offset = boundOffset ? Number(params[params.length - 1]) : 0;
+      if (limit !== undefined && Number.isFinite(limit)) {
+        result = result.slice(offset, offset + limit);
       }
 
       return result as T[];

--- a/tests/unit/ledger/storage.test.ts
+++ b/tests/unit/ledger/storage.test.ts
@@ -351,6 +351,14 @@ describe('LedgerStorage.list', () => {
     assert.strictEqual(results.length, 2);
   });
 
+  it('should respect offset option', () => {
+    const firstPage = storage.list(MOCK_USER_ID, { limit: 2 });
+    const secondPage = storage.list(MOCK_USER_ID, { limit: 2, offset: 2 });
+
+    assert.strictEqual(secondPage.length, 2);
+    assert.notStrictEqual(secondPage[0].id, firstPage[0].id);
+  });
+
   it('should filter by category', () => {
     const results = storage.list(MOCK_USER_ID, { category: 'trade' });
 


### PR DESCRIPTION
Closes #112\n\nWhat changed:\n- teach the in-memory ledger DB mock to honor bound LIMIT and OFFSET values\n- add offset coverage alongside the existing limit assertion\n- unref circuit-breaker auto-reset timers so standalone test and CLI processes can exit\n- clear pending auto-reset timers during manual reset\n\nVerification:\n- standalone ledger storage suite: 34 tests passed\n- trading-safety plus ledger storage in one node test invocation: 55 tests passed and exited normally\n- npm run ci: 188 tests passed, typecheck and build passed