### PR TITLE
fix(futures): value market orders using venue prices

### DIFF
--- a/src/execution/futures.ts
+++ b/src/execution/futures.ts
@@ -1405,11 +1405,15 @@ export function createFuturesExecutionService(config: FuturesConfig): FuturesExe
   const maxPositionSize = config.maxPositionSize ?? 10000; // $10k default
 
   async function resolveOrderPrice(request: FuturesOrderRequest): Promise<number> {
-    if (request.price !== undefined && Number.isFinite(request.price) && request.price > 0) {
-      return request.price;
-    }
-    if (request.stopPrice !== undefined && Number.isFinite(request.stopPrice) && request.stopPrice > 0) {
-      return request.stopPrice;
+    // Market orders (including the default type) do not execute at caller prices.
+    // Value them from the venue so price/stopPrice cannot understate exposure.
+    if (request.orderType && request.orderType !== 'MARKET') {
+      if (request.price !== undefined && Number.isFinite(request.price) && request.price > 0) {
+        return request.price;
+      }
+      if (request.stopPrice !== undefined && Number.isFinite(request.stopPrice) && request.stopPrice > 0) {
+        return request.stopPrice;
+      }
     }
 
     switch (request.platform) {
@@ -1452,7 +1456,9 @@ export function createFuturesExecutionService(config: FuturesConfig): FuturesExe
       try {
         if (request.platform === 'mexc' && config.mexc) {
           const valuation = await getMexcOrderValuation(config.mexc, request.symbol);
-          checkPrice = request.price ?? request.stopPrice ?? valuation.price;
+          checkPrice = request.orderType && request.orderType !== 'MARKET'
+            ? request.price ?? request.stopPrice ?? valuation.price
+            : valuation.price;
           contractSize = valuation.contractSize;
         } else {
           checkPrice = await resolveOrderPrice(request);

--- a/src/trading/futures/index.ts
+++ b/src/trading/futures/index.ts
@@ -5373,7 +5373,8 @@ export class FuturesService extends EventEmitter {
     if (order.reduceOnly) {
       gateError = null;
     } else {
-      let price = order.price ?? order.stopPrice;
+      // Caller prices do not constrain a market fill; always discover its value.
+      let price = order.type === 'MARKET' ? undefined : order.price ?? order.stopPrice;
       let contractSize = 1;
       if (exchange === 'mexc') {
         const market = (await this.getMarkets(exchange)).find(item => item.symbol === order.symbol);

--- a/tests/trading/futures-pre-trade.test.ts
+++ b/tests/trading/futures-pre-trade.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, describe, it, type TestContext } from 'node:test';
 import assert from 'node:assert/strict';
 import { createFuturesExecutionService } from '../../src/execution/futures';
 import { FuturesService } from '../../src/trading/futures';
@@ -97,5 +97,160 @@ describe('futures pre-trade enforcement', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+const priceHints = [
+  { name: 'price', fields: { price: 1 } },
+  { name: 'stopPrice', fields: { stopPrice: 1 } },
+  { name: 'both price fields', fields: { price: 1, stopPrice: 1 } },
+];
+
+// Keep price discovery offline while exercising the actual venue response parsing.
+function mockExecutionPrice(t: TestContext, price: number | string = 60_000) {
+  return t.mock.method(globalThis, 'fetch', async (...[input, init]: Parameters<typeof fetch>) => {
+    const url = new URL(String(input));
+    assert.equal(init?.method, 'GET');
+    let body: unknown;
+    switch (url.pathname) {
+      case '/fapi/v1/premiumIndex':
+        body = { markPrice: String(price) };
+        break;
+      case '/api/v1/contract/ticker':
+        body = { code: 0, data: { lastPrice: String(price) } };
+        break;
+      case '/api/v1/contract/detail':
+        body = { code: 0, data: [{ symbol: 'BTC_USDT', contractSize: 0.0001 }] };
+        break;
+      default:
+        assert.fail(`Unexpected request: ${url.pathname}`);
+    }
+    return new Response(JSON.stringify(body), { status: 200 });
+  });
+}
+
+for (const platform of ['binance', 'mexc'] as const) {
+  const symbol = platform === 'mexc' ? 'BTC_USDT' : 'BTCUSDT';
+  // Both sizes are worth $600 at the venue price, including MEXC's multiplier.
+  const size = platform === 'mexc' ? 100 : 0.01;
+
+  describe(`${platform} market-order valuation`, () => {
+    for (const hint of priceHints) {
+      for (const orderType of ['MARKET', undefined] as const) {
+        it(`execution engine ignores ${hint.name} for ${orderType ?? 'default MARKET'} orders`, async (t) => {
+          configurePreTradeGate({ maxOrderSize: 500 });
+          const priceLookup = mockExecutionPrice(t);
+          const service = createFuturesExecutionService({
+            [platform]: { apiKey: 'test', secretKey: 'test' },
+            dryRun: true,
+          });
+
+          const result = await service.openLong({
+            platform, symbol, size, orderType, ...hint.fields,
+          });
+
+          assert.equal(result.success, false);
+          assert.match(result.error ?? '', /order size \$600\.00 exceeds max \$500/);
+          assert.ok(priceLookup.mock.callCount() > 0);
+        });
+      }
+
+      it(`trading engine ignores ${hint.name} for MARKET orders`, async (t) => {
+        configurePreTradeGate({ maxOrderSize: 500 });
+        const service = new FuturesService([{
+          exchange: platform,
+          credentials: { apiKey: 'test', apiSecret: 'test' },
+          dryRun: true,
+        }]);
+        const priceLookup = platform === 'mexc'
+          ? t.mock.method(service, 'getMarkets', async () => [
+            { symbol, markPrice: 60_000, contractSize: 0.0001 },
+          ])
+          : t.mock.method(service, 'getTickerPrice', async () => [
+            { symbol, price: 60_000, timestamp: Date.now() },
+          ]);
+
+        await assert.rejects(service.placeOrder(platform, {
+          symbol, side: 'BUY', type: 'MARKET', size, ...hint.fields,
+        }), /order size \$600\.00 exceeds max \$500/);
+        assert.equal(priceLookup.mock.callCount(), 1);
+      });
+    }
+
+    it('execution engine permits an under-cap market order despite a high price hint', async (t) => {
+      configurePreTradeGate({ maxOrderSize: 500 });
+      mockExecutionPrice(t);
+      const service = createFuturesExecutionService({
+        [platform]: { apiKey: 'test', secretKey: 'test' },
+        dryRun: true,
+      });
+
+      const result = await service.openLong({
+        platform, symbol, size: size / 10, price: 1_000_000, orderType: 'MARKET',
+      });
+
+      assert.equal(result.success, true);
+    });
+  });
+}
+
+describe('futures market-price discovery failures', () => {
+  for (const price of [0, -1, 'invalid']) {
+    it(`execution engine rejects venue price ${price} despite valid caller prices`, async (t) => {
+      configurePreTradeGate({ maxOrderSize: 500 });
+      mockExecutionPrice(t, price);
+      const service = createFuturesExecutionService({
+        binance: { apiKey: 'test', secretKey: 'test' },
+        dryRun: true,
+      });
+
+      const result = await service.openLong({
+        platform: 'binance', symbol: 'BTCUSDT', size: 1, price: 1, stopPrice: 1,
+      });
+
+      assert.equal(result.success, false);
+      assert.match(result.error ?? '', /No valid Binance mark price/);
+    });
+  }
+
+  it('trading engine rejects a missing quote despite valid caller prices', async (t) => {
+    configurePreTradeGate({ maxOrderSize: 500 });
+    const service = new FuturesService([{
+      exchange: 'binance',
+      credentials: { apiKey: 'test', apiSecret: 'test' },
+      dryRun: true,
+    }]);
+    t.mock.method(service, 'getTickerPrice', async () => []);
+
+    await assert.rejects(service.placeOrder('binance', {
+      symbol: 'BTCUSDT', side: 'BUY', type: 'MARKET', size: 1, price: 1, stopPrice: 1,
+    }), /USD notional could not be determined/);
+  });
+});
+
+describe('futures limit-order valuation', () => {
+  it('keeps using the submitted limit price without market-price discovery', async (t) => {
+    configurePreTradeGate({ maxOrderSize: 500 });
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () => {
+      assert.fail('Limit orders must not need a market quote');
+    });
+    const executionService = createFuturesExecutionService({
+      binance: { apiKey: 'test', secretKey: 'test' },
+      dryRun: true,
+    });
+    const tradingService = new FuturesService([{
+      exchange: 'binance',
+      credentials: { apiKey: 'test', apiSecret: 'test' },
+      dryRun: true,
+    }]);
+
+    const result = await executionService.placeLimitOrder({
+      platform: 'binance', symbol: 'BTCUSDT', side: 'long', size: 0.01, price: 40_000,
+    });
+    assert.equal(result.success, true);
+    await tradingService.placeOrder('binance', {
+      symbol: 'BTCUSDT', side: 'BUY', type: 'LIMIT', size: 0.01, price: 40_000,
+    });
+    assert.equal(fetchMock.mock.callCount(), 0);
   });
 });


### PR DESCRIPTION
Addresses item 1 of #126 (reported by @walt-verweij).

A market order can include a `price` or `stopPrice` that the venue does not use to determine its fill. Both futures engines currently use those fields for the pre-trade notional check. For example, a 0.01 BTC market buy with `price: 1` passes a $500 cap as $0.01, even when the venue quote values it at $600.

This change always discovers the venue price for `MARKET` orders in both engines, including the execution service's default order type. The separate MEXC valuation path uses that price with the existing contract multiplier. Limit/conditional-order valuation and reduce-only handling retain their existing behavior.

The tests cover understated `price`, `stopPrice`, and both together; explicit/default market orders; MEXC contract sizing; missing/invalid quotes; an under-cap market order with an overstated price; and limit orders that should not fetch a quote. All trading is simulated.

Validation on Windows, Node 24.14.0:

- Focused futures suite: **29/29 passed**. Before the source changes, **24 regression cases failed** against `c930628`.
- `npm run typecheck`, `npm run build`, strict standalone typechecking of the modified test file, and `git diff --check` passed.
- `npm test`: 433 passed, 3 failed, 3 skipped, plus API suite initialization errors. The same failures reproduce on unchanged `c930628`: the public checkout lacks `src/api/apikeys` and `src/api/gateway`, and `multichain-race-urls.test.ts` tries to launch the extensionless `tsx` shim on Windows.
- `npm audit` reports 22 existing dependency findings (15 moderate, 6 high, 1 critical). The dependency manifest and lockfile are unchanged. Local installation required `npm ci --force` because `helius-laserstream@0.1.8` excludes Windows; the repository's existing `ignore-scripts=true` remained in effect.
- The CI `audit-ci` wrapper exits locally with `code undefined`; the audit counts above come from `npm audit --json` directly.

This intentionally addresses only the market-order valuation item in #126; the sibling entry points and Jupiter dry-run item remain open.
